### PR TITLE
Implement Today screen layout

### DIFF
--- a/Jeune/Components/FastingRingView.swift
+++ b/Jeune/Components/FastingRingView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct FastingRingView: View {
+    @Binding var progress: Double
+    var lineWidth: CGFloat = 12
+
+    private var gradient: AngularGradient {
+        AngularGradient(
+            gradient: Gradient(colors: [
+                Color.jeunePrimaryColor,
+                progress >= 1.0 ? Color.jeuneSuccessColor : Color.jeunePrimaryColor
+            ]),
+            center: .center
+        )
+    }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.jeunePrimaryColor.opacity(0.2), lineWidth: lineWidth)
+
+            Circle()
+                .trim(from: 0, to: min(progress, 1.0))
+                .stroke(gradient, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+                .animation(.easeInOut, value: progress)
+        }
+    }
+}

--- a/Jeune/Components/StatCard.swift
+++ b/Jeune/Components/StatCard.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct StatCard: View {
+    let icon: String
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundColor(.jeunePrimaryColor)
+            Text(title)
+                .font(.caption)
+                .foregroundColor(.jeuneGrayColor)
+            Text(value)
+                .font(.headline)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.jeuneBGLightColor)
+        .cornerRadius(12)
+    }
+}

--- a/Jeune/Features/RootTab/Today/TodayView.swift
+++ b/Jeune/Features/RootTab/Today/TodayView.swift
@@ -1,12 +1,41 @@
-// TodayView.swift
 import SwiftUI
 
 struct TodayView: View {
+    @StateObject private var vm = TodayViewModel()
+
     var body: some View {
         NavigationView {
-            Text("Today View")
-                .font(.jeuneLargeTitle) // Uses font from Font+Jeune.swift
-                .navigationTitle("Today")
+            ScrollView {
+                VStack(spacing: 24) {
+                    FastingRingView(progress: $vm.progress)
+                        .frame(width: 260, height: 260)
+                        .padding(.top, 16)
+
+                    VStack(spacing: 4) {
+                        Text(vm.timeRemaining)
+                            .font(.system(size: 56, weight: .black, design: .rounded))
+                        Text(vm.zoneLabel)
+                            .font(.caption)
+                            .foregroundColor(.jeuneGrayColor)
+                    }
+
+                    PrimaryButton(title: vm.isRunning ? "End Fast" : "Start Fast") {
+                        vm.primaryAction()
+                    }
+                    .frame(maxWidth: 240)
+
+                    HStack(spacing: 12) {
+                        StatCard(icon: "flame.fill", title: "Streak", value: "\(vm.streak) d")
+                        StatCard(icon: "chart.bar", title: "Avg Fast", value: vm.avgFast)
+                    }
+                }
+            }
+            .navigationTitle("Today")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: vm.addEntry) { Image(systemName: "plus") }
+                }
+            }
         }
     }
 }

--- a/Jeune/Features/RootTab/Today/TodayViewModel.swift
+++ b/Jeune/Features/RootTab/Today/TodayViewModel.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+import Combine
+
+final class TodayViewModel: ObservableObject {
+    @Published var progress: Double = 0
+    @Published var isRunning: Bool = false
+    @Published var streak: Int = 0
+    @Published var avgFast: String = "--"
+
+    private var timer: AnyCancellable?
+
+    var timeRemaining: String {
+        // Placeholder: represent hours remaining until complete
+        let hours = Int((1.0 - min(progress, 1.0)) * 24)
+        return "\(hours)h"
+    }
+
+    var zoneLabel: String {
+        progress >= 1.0 ? "Complete" : "Fasting"
+    }
+
+    func primaryAction() {
+        isRunning.toggle()
+    }
+
+    func addEntry() {
+        // Placeholder for adding a fasting entry
+    }
+}


### PR DESCRIPTION
## Summary
- add `FastingRingView` progress ring component
- add `StatCard` component for quick stats
- create a basic `TodayViewModel`
- build out `TodayView` layout with ring, timer, and stats

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project Jeune.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683e1ac45b388324bf19876dc0b41cd6