### PR TITLE
Add responsive FastCalendar to Me view

### DIFF
--- a/Jeune/Features/RootTab/Me/FastCalendar.swift
+++ b/Jeune/Features/RootTab/Me/FastCalendar.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Grid calendar showing fasting durations as coloured dots.
+/// Designed to fit 7 columns on small screens without overlapping.
+struct FastCalendar: View {
+    @Binding var selectedDate: Date
+    var fasts: [Double] // fasting hours for each day
+
+    private let spacing: CGFloat = 4
+    private var columns: [GridItem] {
+        Array(repeating: GridItem(.flexible(), spacing: spacing), count: 7)
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            let itemSize = (geometry.size.width - spacing * 6) / 7
+            LazyVGrid(columns: columns, spacing: spacing) {
+                ForEach(fasts.indices, id: \._self) { index in
+                    Circle()
+                        .fill(Color.jeunePrimaryColor)
+                        .opacity(min(1, fasts[index] / 24))
+                        .frame(width: itemSize, height: itemSize)
+                }
+            }
+        }
+        // Maintain aspect ratio so the grid doesn't overflow vertically.
+        .aspectRatio(7/6, contentMode: .fit)
+    }
+}
+
+#Preview {
+    FastCalendar(selectedDate: .constant(Date()), fasts: Array(repeating: 8, count: 42))
+        .padding()
+}

--- a/Jeune/Features/RootTab/Me/MeView.swift
+++ b/Jeune/Features/RootTab/Me/MeView.swift
@@ -1,12 +1,50 @@
 // MeView.swift
 import SwiftUI
 
+/// Displays user metrics and a heat-map style calendar of recent fasts.
 struct MeView: View {
+    @State private var selectedDate: Date = .init()
+
+    // Placeholder fast data representing fasting duration for each day
+    // in the 7×6 grid shown by ``FastCalendar``.
+    private var fasts: [Double] = Array(repeating: 0, count: 42)
+
     var body: some View {
         NavigationView {
-            Text("Me View")
-                .font(.jeuneLargeTitle)
-                .navigationTitle("Me")
+            ScrollView {
+                VStack(spacing: 24) {
+                    header
+
+                    FastCalendar(selectedDate: $selectedDate, fasts: fasts)
+                }
+                .padding(.horizontal)
+            }
+            .navigationTitle("Me")
         }
     }
+
+    /// The header showing the latest weight and a plus button.
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Text("Current weight")
+                    .font(.caption)
+                Text("72 kg")
+                    .font(.title)
+                    .bold()
+            }
+            Spacer()
+            Button(action: { /* add weight action */ }) {
+                Image(systemName: "plus")
+                    .padding(8)
+                    .background(Color.jeunePrimaryColor)
+                    .foregroundColor(.white)
+                    .clipShape(Circle())
+            }
+        }
+    }
+}
+
+#Preview {
+    MeView()
 }


### PR DESCRIPTION
## Summary
- implement `FastCalendar` component using `LazyVGrid`
- update `MeView` to show header and calendar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683e1afaa33483249685e2b1a24ae0c5