### PR TITLE
Fix FastCalendar ForEach id

### DIFF
--- a/Jeune/Features/RootTab/Me/FastCalendar.swift
+++ b/Jeune/Features/RootTab/Me/FastCalendar.swift
@@ -15,7 +15,7 @@ struct FastCalendar: View {
         GeometryReader { geometry in
             let itemSize = (geometry.size.width - spacing * 6) / 7
             LazyVGrid(columns: columns, spacing: spacing) {
-                ForEach(fasts.indices, id: \._self) { index in
+                ForEach(fasts.indices, id: \.self) { index in
                     Circle()
                         .fill(Color.jeunePrimaryColor)
                         .opacity(min(1, fasts[index] / 24))


### PR DESCRIPTION
## Summary
- fix the key path for `ForEach` in `FastCalendar`

## Testing
- `swiftc Jeune/Features/RootTab/Me/FastCalendar.swift -o /tmp/test 2>&1 | head` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_b_683e1f897d6c8324b7a3e0e04f12d605