### PR TITLE
Implement home screen design components

### DIFF
--- a/Jeune/Components/ChallengesCardView.swift
+++ b/Jeune/Components/ChallengesCardView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+/// Placeholder card showing upcoming challenges section.
+struct ChallengesCardView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("Challenges")
+                    .font(.title3.weight(.semibold))
+                Spacer()
+                Text("SEE ALL")
+                    .font(.caption.bold())
+                    .foregroundColor(.jeunePrimaryColor)
+            }
+
+            HStack(spacing: 12) {
+                Image(systemName: "flame.fill")
+                    .foregroundColor(.jeunePrimaryColor)
+                    .font(.title2)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Join challenges to earn achievements")
+                        .font(.subheadline)
+                        .lineLimit(2)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .foregroundColor(.jeunePrimaryColor)
+            }
+            .frame(height: 80)
+            .frame(maxWidth: .infinity)
+            .background(Color(red: 0.94, green: 0.94, blue: 0.95))
+            .clipShape(RoundedRectangle(cornerRadius: 20))
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity)
+        .background(Color.jeuneCardColor)
+        .cornerRadius(DesignConstants.cornerRadius)
+        .shadow(color: DesignConstants.cardShadow, radius: 10, y: 1)
+    }
+}
+
+#Preview {
+    ChallengesCardView()
+        .padding()
+}

--- a/Jeune/Components/FastTimerCardView.swift
+++ b/Jeune/Components/FastTimerCardView.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+enum FastTimerState {
+    case idle(days: Int)
+    case running(progress: Double)
+}
+
+/// Card displaying the fasting timer ring and CTA button.
+struct FastTimerCardView: View {
+    var state: FastTimerState
+    var startDate: String = "--"
+    var goal: String = "16h"
+    var action: () -> Void
+
+    private var progress: Double {
+        switch state {
+        case .idle: return 0
+        case .running(let p): return p
+        }
+    }
+
+    private var buttonTitle: String {
+        switch state {
+        case .idle: return "Start Fasting"
+        case .running: return "Break Your Fast"
+        }
+    }
+
+    private var buttonColor: Color {
+        switch state {
+        case .idle: return .jeunePrimaryColor
+        case .running: return .jeuneSuccessColor
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 24) {
+            RingView(progress: progress,
+                     diameter: 260,
+                     lineWidth: 12)
+
+            centerContent
+
+            if case .running = state {
+                statsRow
+            }
+
+            PrimaryCTAButton(title: buttonTitle,
+                              background: buttonColor,
+                              action: action)
+                .padding(.horizontal, 24)
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity)
+        .background(Color.jeuneCardColor)
+        .cornerRadius(DesignConstants.cornerRadius)
+        .shadow(color: DesignConstants.cardShadow, radius: 10, y: 1)
+    }
+
+    @ViewBuilder
+    private var centerContent: some View {
+        switch state {
+        case .idle(let days):
+            VStack(spacing: 4) {
+                Text("SINCE LAST FAST")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .textCase(.uppercase)
+                Text("\(days) days")
+                    .font(.system(size: 56, weight: .black, design: .rounded))
+                Text("EDIT \(goal.uppercased()) GOAL")
+                    .font(.caption2)
+                    .foregroundColor(.jeunePrimaryColor)
+            }
+        case .running(let p):
+            VStack(spacing: 4) {
+                Text(timeString(from: p))
+                    .font(.system(size: 56, weight: .black, design: .rounded))
+                Text("ELAPSED")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    private var statsRow: some View {
+        HStack(spacing: 8) {
+            statCapsule(title: "STARTED", value: startDate)
+            statCapsule(title: "\(goal) GOAL", value: goal)
+        }
+        .padding(.horizontal, 24)
+    }
+
+    private func statCapsule(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+            Text(value)
+                .font(.subheadline.weight(.semibold))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(Color.jeuneBGLightColor)
+        .cornerRadius(20)
+    }
+
+    private func timeString(from progress: Double) -> String {
+        let totalSeconds = Int(progress * 3600 * 16)
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+        return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+    }
+}
+
+#Preview {
+    FastTimerCardView(state: .idle(days: 135)) {}
+        .padding()
+}

--- a/Jeune/Components/MiniRingView.swift
+++ b/Jeune/Components/MiniRingView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// Small ring with a weekday label underneath.
+struct MiniRingView: View {
+    var progress: Double
+    var weekday: String
+
+    var body: some View {
+        VStack(spacing: 4) {
+            RingView(progress: progress,
+                     diameter: 30,
+                     lineWidth: 4)
+            Text(weekday)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+    }
+}
+
+#Preview {
+    MiniRingView(progress: 0.5, weekday: "MON")
+}

--- a/Jeune/Components/PrimaryCTAButton.swift
+++ b/Jeune/Components/PrimaryCTAButton.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Primary pill-shaped call to action.
+struct PrimaryCTAButton: View {
+    var title: String
+    var background: Color
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.headline.weight(.semibold))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: DesignConstants.primaryCTAHeight)
+                .background(background)
+                .cornerRadius(28)
+        }
+    }
+}
+
+#Preview {
+    PrimaryCTAButton(title: "Start Fasting", background: .jeunePrimaryColor) {}
+}

--- a/Jeune/Components/RingView.swift
+++ b/Jeune/Components/RingView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// Circular progress ring used throughout the home screen.
+struct RingView: View {
+    var progress: Double
+    var diameter: CGFloat
+    var lineWidth: CGFloat
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.jeuneRingTrackColor, lineWidth: lineWidth)
+
+            Circle()
+                .trim(from: 0, to: min(progress, 1))
+                .stroke(progress >= 1.0 ? Color.jeuneSuccessColor : Color.jeunePrimaryColor,
+                        style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+                .animation(.easeInOut, value: progress)
+        }
+        .frame(width: diameter, height: diameter)
+    }
+}
+
+#Preview {
+    RingView(progress: 0.7, diameter: 100, lineWidth: 12)
+}

--- a/Jeune/Components/StreakBadgeView.swift
+++ b/Jeune/Components/StreakBadgeView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Circular badge used in the home toolbar to indicate streak count.
+struct StreakBadgeView: View {
+    var count: Int
+
+    private var backgroundColor: Color {
+        count > 0 ? .jeunePrimaryColor : .jeuneRingTrackColor
+    }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ZStack {
+                Circle()
+                    .fill(backgroundColor)
+                    .frame(width: DesignConstants.toolbarButtonSize,
+                           height: DesignConstants.toolbarButtonSize)
+                Image(systemName: "checkmark")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundColor(.white)
+            }
+
+            Text("\(count)")
+                .font(.caption.weight(.semibold))
+        }
+    }
+}
+
+#Preview {
+    VStack {
+        StreakBadgeView(count: 0)
+        StreakBadgeView(count: 5)
+    }
+}

--- a/Jeune/Core/Utilities/Color+Jeune.swift
+++ b/Jeune/Core/Utilities/Color+Jeune.swift
@@ -20,6 +20,15 @@ extension Color {
     /// Default dark background colour.
     static let jeuneBGDarkColor       = Color("jeuneBGDark")
 
+    /// Very light warm grey used for the main app canvas.
+    static let jeuneCanvasColor       = Color("jeuneCanvas")
+
+    /// Standard card background colour.
+    static let jeuneCardColor         = Color("jeuneCard")
+
+    /// Neutral track colour for progress rings.
+    static let jeuneRingTrackColor    = Color("jeuneRingTrack")
+
     // Category colours
     static let jeuneNutritionColor    = Color("jeuneNutrition")
     static let jeuneActivityColor     = Color("jeuneActivity")

--- a/Jeune/Core/Utilities/DesignConstants.swift
+++ b/Jeune/Core/Utilities/DesignConstants.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+/// Centralised design constants derived from `tasks.md`.
+enum DesignConstants {
+    /// Default corner radius for cards and buttons.
+    static let cornerRadius: CGFloat = 24
+
+    /// Shadow used for cards.
+    static let cardShadow = Color.black.opacity(0.05)
+
+    /// Toolbar button size.
+    static let toolbarButtonSize: CGFloat = 34
+
+    /// Primary call to action button height.
+    static let primaryCTAHeight: CGFloat = 54
+}

--- a/Jeune/Features/JeuneHomeView.swift
+++ b/Jeune/Features/JeuneHomeView.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+struct JeuneHomeView: View {
+    @State private var progress: Double = 0.6
+    @State private var streak: Int = 3
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    weekStrip
+                    FastTimerCardView(state: .running(progress: progress)) {
+                        // action placeholder
+                    }
+                    ChallengesCardView()
+                }
+                .padding(.top, 24)
+                .padding(.horizontal)
+            }
+            .background(Color.jeuneCanvasColor.ignoresSafeArea())
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    StreakBadgeView(count: streak)
+                }
+                ToolbarItem(placement: .principal) {
+                    Image("logojeune")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(height: 24)
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {}) {
+                        Image(systemName: "plus")
+                            .font(.title3)
+                            .foregroundColor(.white)
+                            .frame(width: DesignConstants.toolbarButtonSize,
+                                   height: DesignConstants.toolbarButtonSize)
+                            .background(Color.jeunePrimaryColor)
+                            .clipShape(Circle())
+                    }
+                }
+            }
+        }
+    }
+
+    private var weekStrip: some View {
+        HStack(spacing: 20) {
+            ForEach(0..<7) { index in
+                MiniRingView(progress: Double(index) / 6, weekday: weekdayLabel(for: index))
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func weekdayLabel(for index: Int) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.setLocalizedDateFormatFromTemplate("EEE")
+        let date = Calendar.current.date(byAdding: .day, value: index, to: startOfWeek())!
+        return formatter.string(from: date).uppercased()
+    }
+
+    private func startOfWeek() -> Date {
+        let cal = Calendar.current
+        let comps = cal.dateComponents([.yearForWeekOfYear, .weekOfYear], from: Date())
+        return cal.date(from: comps) ?? Date()
+    }
+}
+
+#Preview {
+    JeuneHomeView()
+}

--- a/Jeune/HomePreviewProvider.swift
+++ b/Jeune/HomePreviewProvider.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+struct HomePreviewProvider: PreviewProvider {
+    static var previews: some View {
+        JeuneHomeView()
+    }
+}

--- a/Jeune/Resources/Assets.xcassets/jeuneCanvas.colorset/Contents.json
+++ b/Jeune/Resources/Assets.xcassets/jeuneCanvas.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.969",
+          "green" : "0.969",
+          "blue" : "0.976",
+          "alpha" : "1.000"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Jeune/Resources/Assets.xcassets/jeuneCard.colorset/Contents.json
+++ b/Jeune/Resources/Assets.xcassets/jeuneCard.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "1.000",
+          "green" : "1.000",
+          "blue" : "1.000",
+          "alpha" : "1.000"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Jeune/Resources/Assets.xcassets/jeuneRingTrack.colorset/Contents.json
+++ b/Jeune/Resources/Assets.xcassets/jeuneRingTrack.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.882",
+          "green" : "0.882",
+          "blue" : "0.890",
+          "alpha" : "1.000"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}


### PR DESCRIPTION
## Summary
- add color tokens and design constants
- implement RingView, MiniRingView and streak badge
- add primary CTA button and fast timer card
- implement challenges card
- create JeuneHomeView with week strip and toolbar
- provide HomePreviewProvider

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_683f31b7ebf48324889c48808539582f