### PR TITLE
UI updates from tasks

### DIFF
--- a/Jeune/Components/ChallengesCardView.swift
+++ b/Jeune/Components/ChallengesCardView.swift
@@ -31,8 +31,8 @@ struct ChallengesCardView: View {
             .background(Color(red: 0.94, green: 0.94, blue: 0.95))
             .clipShape(RoundedRectangle(cornerRadius: 20))
         }
-        .padding(.vertical, 24)
-        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+        .padding(.horizontal, 16)
         .frame(maxWidth: .infinity)
         .background(Color.jeuneCardColor)
         .cornerRadius(DesignConstants.cornerRadius)

--- a/Jeune/Components/DayIndicatorView.swift
+++ b/Jeune/Components/DayIndicatorView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+/// Circular day indicator used in the home screen week strip.
+struct DayIndicatorView: View {
+    enum State {
+        case selected
+        case inactive
+        case completed
+    }
+
+    var label: String
+    var state: State
+
+    private var ringColor: Color {
+        switch state {
+        case .selected:  return .jeunePrimaryColor
+        case .inactive:  return .jeuneRingTrackColor
+        case .completed: return .jeuneSuccessColor
+        }
+    }
+
+    private var textColor: Color {
+        switch state {
+        case .inactive:  return .secondary
+        case .completed: return .jeuneSuccessColor
+        case .selected:  return .white
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 4) {
+            ZStack {
+                Circle()
+                    .stroke(ringColor, lineWidth: state == .inactive ? 2 : 4)
+                    .frame(width: DesignConstants.miniRingDiameter + 6,
+                           height: DesignConstants.miniRingDiameter + 6)
+
+                if state == .selected {
+                    Circle()
+                        .fill(ringColor)
+                        .frame(width: DesignConstants.miniRingDiameter - 4,
+                               height: DesignConstants.miniRingDiameter - 4)
+                }
+            }
+
+            Text(label)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(state == .selected ? .jeunePrimaryColor : textColor)
+        }
+    }
+}
+
+#Preview {
+    HStack {
+        DayIndicatorView(label: "TUE", state: .selected)
+        DayIndicatorView(label: "WED", state: .inactive)
+        DayIndicatorView(label: "MON", state: .completed)
+    }
+}

--- a/Jeune/Components/FastTimerCardView.swift
+++ b/Jeune/Components/FastTimerCardView.swift
@@ -71,8 +71,7 @@ struct FastTimerCardView: View {
             )
             .padding(.horizontal, 24)
         }
-        .padding(.vertical, 24)
-        .padding(.horizontal, 16)
+        .padding(16)
         .frame(maxWidth: .infinity)
         .background(Color.jeuneCardColor)
         .cornerRadius(DesignConstants.cornerRadius)

--- a/Jeune/Components/StreakBadgeView.swift
+++ b/Jeune/Components/StreakBadgeView.swift
@@ -1,24 +1,23 @@
 import SwiftUI
 
-/// Circular badge used in the home toolbar to indicate streak count.
+/// Capsule badge used in the home toolbar to indicate streak count.
 struct StreakBadgeView: View {
     var count: Int
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 4) {
-            ZStack {
-                Circle()
-                    .fill(Color.jeuneSuccessTintColor)
-                    .frame(width: DesignConstants.toolbarButtonSize,
-                           height: DesignConstants.toolbarButtonSize)
-                Image(systemName: "checkmark")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(.white)
-            }
+        HStack(spacing: 4) {
+            Image(systemName: "checkmark")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.white)
 
             Text("\(count)")
-                .font(.caption.weight(.semibold))
+                .font(.system(size: 16))
+                .foregroundColor(.primary)
         }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Color.jeuneSuccessTintColor)
+        .clipShape(Capsule())
     }
 }
 

--- a/Jeune/Components/ToolbarPlusButtonView.swift
+++ b/Jeune/Components/ToolbarPlusButtonView.swift
@@ -7,7 +7,7 @@ struct ToolbarPlusButtonView: View {
     var body: some View {
         Button(action: action) {
             Image(systemName: "plus")
-                .font(.title2)
+                .font(.system(size: 21, weight: .bold))
                 .foregroundColor(.jeunePrimaryColor)
                 .frame(width: DesignConstants.toolbarButtonSize,
                        height: DesignConstants.toolbarButtonSize)

--- a/Jeune/Core/Utilities/DesignConstants.swift
+++ b/Jeune/Core/Utilities/DesignConstants.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Centralised design constants derived from `tasks.md`.
 enum DesignConstants {
     /// Default corner radius for cards and buttons.
-    static let cornerRadius: CGFloat = 24
+    static let cornerRadius: CGFloat = 20
 
     /// Shadow used for cards.
     static let cardShadow = Color.black.opacity(0.10)

--- a/Jeune/Features/JeuneHomeView.swift
+++ b/Jeune/Features/JeuneHomeView.swift
@@ -34,10 +34,8 @@ struct JeuneHomeView: View {
                 }
 
                 ToolbarItem(placement: .principal) {
-                    Image("logojeune")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(height: 32)
+                    Text("Jeune")
+                        .font(.system(size: 24, weight: .bold))
                 }
 
                 ToolbarItem(placement: .navigationBarTrailing) {
@@ -50,29 +48,30 @@ struct JeuneHomeView: View {
     }
 
     private var weekStrip: some View {
-        HStack(spacing: 16) {
+        HStack(spacing: 20) {
             ForEach(0..<7) { index in
-                MiniRingView(
-                    progress: Double(index) / 6,
-                    weekday: weekdayLabel(for: index)
+                let date = Calendar.current.date(byAdding: .day, value: index, to: Date())!
+                DayIndicatorView(
+                    label: weekdayLabel(for: date),
+                    state: dayState(for: index)
                 )
             }
         }
+        .padding(.vertical, 12)
         .frame(maxWidth: .infinity)
     }
 
-    private func weekdayLabel(for index: Int) -> String {
+    private func weekdayLabel(for date: Date) -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.setLocalizedDateFormatFromTemplate("EEE")
-        let date = Calendar.current.date(byAdding: .day, value: index, to: startOfWeek())!
         return formatter.string(from: date).uppercased()
     }
 
-    private func startOfWeek() -> Date {
-        let cal = Calendar.current
-        let comps = cal.dateComponents([.yearForWeekOfYear, .weekOfYear], from: Date())
-        return cal.date(from: comps) ?? Date()
+    private func dayState(for index: Int) -> DayIndicatorView.State {
+        if index == 0 { return .selected }
+        if index == 6 { return .completed }
+        return .inactive
     }
 }
 


### PR DESCRIPTION
## Summary
- tweak streak badge into capsule layout
- bold plus icon for add button
- update card constants and spacing
- redesign home header and day strip
- add reusable `DayIndicatorView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_683f4d2dc204832482f900a1af65c3ad