### PR TITLE
Implement timer card styles

### DIFF
--- a/Jeune/Components/FastTimerCardView.swift
+++ b/Jeune/Components/FastTimerCardView.swift
@@ -48,15 +48,16 @@ struct FastTimerCardView: View {
     var body: some View {
         VStack(spacing: 24) {
 
-            // Ring
-            RingView(
-                progress:  progress,
-                diameter:  DesignConstants.largeRingDiameter,
-                lineWidth: DesignConstants.largeRingLineWidth
-            )
+            // Ring with centre content overlayed
+            ZStack {
+                RingView(
+                    progress:  progress,
+                    diameter:  DesignConstants.largeRingDiameter,
+                    lineWidth: DesignConstants.largeRingLineWidth
+                )
 
-            // Centre label
-            centreContent
+                centreContent
+            }
 
             // Stats (only while running)
             if case .running = state {
@@ -69,7 +70,7 @@ struct FastTimerCardView: View {
                 background: buttonColor,
                 action:     action
             )
-            .padding(.horizontal, 24)
+            .padding(.horizontal, 16)
         }
         .padding(16)
         .frame(maxWidth: .infinity)
@@ -92,7 +93,8 @@ struct FastTimerCardView: View {
                     .textCase(.uppercase)
 
                 Text("\(days) days")
-                    .font(.system(size: 64, weight: .black, design: .rounded))
+                    .font(.system(size: 56, weight: .heavy))
+                    .foregroundColor(.jeuneNearBlack)
 
                 Text("EDIT \(goalHours)H GOAL")
                     .font(.caption.weight(.semibold))
@@ -101,39 +103,48 @@ struct FastTimerCardView: View {
 
         // ── Running ─────────────────────────────────────────────────────────────
         case .running(let p):
-            VStack(spacing: 4) {
+            VStack(spacing: 6) {
                 Text(timeString(from: p))
-                    .font(.system(size: 64, weight: .black, design: .rounded))
+                    .font(.system(size: 56, weight: .heavy))
+                    .foregroundColor(.jeuneNearBlack)
 
                 Text("ELAPSED (\(Int(p * 100)) %)")
-                    .font(.caption.weight(.semibold))
-                    .foregroundColor(.secondary)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundColor(.jeuneDarkGray)
             }
         }
     }
 
     private var statsRow: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 12) {
             statCapsule(title: "STARTED",            value: startDate)
             statCapsule(title: "\(goalHours)H GOAL", value: goalTime)
         }
+        .padding(8)
+        .background(Color.jeuneStatsBGColor)
+        .clipShape(Capsule())
         .padding(.horizontal, 16)
     }
 
     private func statCapsule(title: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(spacing: 4) {
             Text(title)
-                .font(.caption2)
-                .foregroundColor(.secondary)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(.jeuneGrayColor)
 
             Text(value)
-                .font(.subheadline.weight(.semibold))
+                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(.jeuneNearBlack)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity)
         .padding(8)
         .frame(minHeight: 48)
-        .background(Color.jeuneStatsBGColor)
-        .cornerRadius(20)
+        .background(Color.white)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color(red: 224/255, green: 224/255, blue: 224/255), lineWidth: 1)
+        )
+        .cornerRadius(10)
     }
 
     // MARK: – Helpers

--- a/Jeune/Components/PrimaryCTAButton.swift
+++ b/Jeune/Components/PrimaryCTAButton.swift
@@ -9,12 +9,12 @@ struct PrimaryCTAButton: View {
     var body: some View {
         Button(action: action) {
             Text(title)
-                .font(.headline.weight(.semibold))
+                .font(.system(size: 18, weight: .bold))
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity)
                 .frame(height: DesignConstants.primaryCTAHeight)
                 .background(background)
-                .cornerRadius(28)
+                .clipShape(Capsule())
         }
     }
 }

--- a/Jeune/Core/Utilities/Color+Jeune.swift
+++ b/Jeune/Core/Utilities/Color+Jeune.swift
@@ -38,6 +38,12 @@ extension Color {
     /// Background colour for stats capsules.
     static let jeuneStatsBGColor      = Color("jeuneStatsBG")
 
+    /// Near black used for prominent text elements.
+    static let jeuneNearBlack = Color(red: 28/255, green: 28/255, blue: 30/255)
+
+    /// Dark gray used for secondary labels.
+    static let jeuneDarkGray  = Color(red: 99/255, green: 99/255, blue: 102/255)
+
     // Category colours
     static let jeuneNutritionColor    = Color("jeuneNutrition")
     static let jeuneActivityColor     = Color("jeuneActivity")

--- a/Jeune/Core/Utilities/DesignConstants.swift
+++ b/Jeune/Core/Utilities/DesignConstants.swift
@@ -17,8 +17,9 @@ enum DesignConstants {
     /// Diameter of the large fasting timer ring.
     static let largeRingDiameter: CGFloat = 280
 
-    /// Stroke width for the large fasting timer ring.
-    static let largeRingLineWidth: CGFloat = 24
+    /// Stroke width for the large fasting timer ring. Doubling the thickness
+    /// further emphasises progress of the fast.
+    static let largeRingLineWidth: CGFloat = 80
 
     /// Diameter of the mini weekday progress rings.
     static let miniRingDiameter: CGFloat = 26


### PR DESCRIPTION
## Summary
- add near-black and dark-gray colors
- thicken fasting timer ring
- style the CTA button
- update fast timer font sizes and stat boxes

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_b_683f5055644c8324b8103b296c22b0b7