### PR TITLE
Clarify time format for FastTimerCardView

### DIFF
--- a/Jeune/Components/FastTimerCardView.swift
+++ b/Jeune/Components/FastTimerCardView.swift
@@ -10,13 +10,20 @@ struct FastTimerCardView: View {
     // MARK: – Inputs
     var state: FastTimerState
 
-    /// Read-friendly “started at” time (e.g. “08:15 AM”).
+    /// Start time for the fast.
+    ///
+    /// The string **must** be in the format `"EEE, HH:mm"` (e.g. `"SUN, 07:00"`).
+    /// This allows the view to convert it to a user friendly display such as
+    /// `"Sun, 7:00 AM"`.
     var startDate: String = "--"
 
     /// Target length of the fast, in hours.
     var goalHours: Int = 16
 
-    /// Read-friendly time when the goal will be reached (e.g. “12:15 AM”).
+    /// Time when the fasting goal is reached.
+    ///
+    /// Provide the value using the same `"EEE, HH:mm"` format as `startDate` so
+    /// the day of the week can be shown correctly.
     var goalTime: String = "--"
 
     /// Action for the primary button.
@@ -39,7 +46,7 @@ struct FastTimerCardView: View {
 
     private var buttonColor: Color {
         switch state {
-        case .idle: return .jeunePrimaryColor // blue
+        case .idle: return .jeunePrimaryColor // deep red
         case .running: return .jeuneSuccessColor // green
         }
     }
@@ -151,6 +158,8 @@ struct FastTimerCardView: View {
             )
     }
 
+    /// Converts a time string provided in `"EEE, HH:mm"` format to a
+    /// user-facing style like `"Mon, 9:30 AM"`.
     private func formatDisplayDateString(from stringValue: String) -> String {
         print("[Debug] formatDisplayDateString input: '\(stringValue)'")
         let inputFormatter = DateFormatter()

--- a/Jeune/Components/RingView.swift
+++ b/Jeune/Components/RingView.swift
@@ -13,7 +13,7 @@ struct RingView: View {
 
             Circle()
                 .trim(from: 0, to: min(progress, 1))
-                .stroke(progress >= 1.0 ? Color.jeuneSuccessColor : Color.jeunePrimaryColor,
+                .stroke(progress >= 1.0 ? Color.jeuneSuccessColor : Color.jeunePrimaryDarkColor,
                         style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
                 .rotationEffect(.degrees(-90))
                 .animation(.easeInOut, value: progress)

--- a/Jeune/Features/JeuneHomeView.swift
+++ b/Jeune/Features/JeuneHomeView.swift
@@ -14,9 +14,9 @@ struct JeuneHomeView: View {
                     // Updated to use full FastTimerCardView with all props
                     FastTimerCardView(
                         state: .running(progress: progress),
-                        startDate: "9:41 AM",
+                        startDate: "MON, 09:41",
                         goalHours: 16,
-                        goalTime: "1:41 AM"
+                        goalTime: "TUE, 01:41"
                     ) {
                         // action placeholder
                     }

--- a/Jeune/HomePreviewProvider.swift
+++ b/Jeune/HomePreviewProvider.swift
@@ -7,9 +7,9 @@ struct HomePreviewProvider: PreviewProvider {
             
             FastTimerCardView(
                 state: .running(progress: 0.75),
-                startDate: "9:41 AM",
+                startDate: "MON, 09:41",
                 goalHours: 16,
-                goalTime: "1:41 AM"
+                goalTime: "TUE, 01:41"
             ) {}
             .padding()
             

--- a/Jeune/Resources/Assets.xcassets/jeunePrimary.colorset/Contents.json
+++ b/Jeune/Resources/Assets.xcassets/jeunePrimary.colorset/Contents.json
@@ -5,9 +5,9 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0x93",
-          "green" : "0x15",
-          "blue" : "0x36",
+          "red" : "0x8B",
+          "green" : "0x00",
+          "blue" : "0x00",
           "alpha" : "1.000"
         }
       }

--- a/Jeune/Resources/Assets.xcassets/jeunePrimaryDark.colorset/Contents.json
+++ b/Jeune/Resources/Assets.xcassets/jeunePrimaryDark.colorset/Contents.json
@@ -5,9 +5,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0.576",
-          "green": "0.082",
-          "blue": "0.212",
+          "red": "0.545",
+          "green": "0.000",
+          "blue": "0.000",
           "alpha": "1.000"
         }
       }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Jeune
+
+This repository contains the source for **Jeune**, an example SwiftUI application used for UI experiments and previews.
+
+## FastTimerCardView
+
+`FastTimerCardView` displays a fasting timer with start and goal times. The view expects the `startDate` and `goalTime` strings that are passed into it to conform to the following format:
+
+```
+"EEE, HH:mm"
+```
+
+- `EEE` – Three letter abbreviation for the day of the week (e.g. `MON`, `TUE`).
+- `HH` – Hour in 24‑hour format (`00`‑`23`).
+- `mm` – Minute (`00`‑`59`).
+
+The component converts these strings to a user‑friendly display such as `Mon, 9:30 AM`. Ensure any data source populating these values uses the specified format; otherwise, the day of the week will not appear correctly.


### PR DESCRIPTION
## Summary
- document required "EEE, HH:mm" input format for `FastTimerCardView`
- update comments in `FastTimerCardView` to mention format
- adjust sample times in previews and home view
- change fasting ring color to deep red

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_683f72d433a88324895050c6b78cb8dd