### PR TITLE
Update primary brand color

### DIFF
--- a/Jeune/Resources/Assets.xcassets/jeunePrimary.colorset/Contents.json
+++ b/Jeune/Resources/Assets.xcassets/jeunePrimary.colorset/Contents.json
@@ -5,9 +5,9 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0x8B",
-          "green" : "0x00",
-          "blue" : "0x00",
+          "red" : "0xA0",
+          "green" : "0x32",
+          "blue" : "0x32",
           "alpha" : "1.000"
         }
       }

--- a/Jeune/Resources/Assets.xcassets/jeunePrimaryDark.colorset/Contents.json
+++ b/Jeune/Resources/Assets.xcassets/jeunePrimaryDark.colorset/Contents.json
@@ -5,9 +5,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0.545",
-          "green": "0.000",
-          "blue": "0.000",
+          "red": "0.627",
+          "green": "0.196",
+          "blue": "0.196",
           "alpha": "1.000"
         }
       }


### PR DESCRIPTION
## Summary
- tweak jeunePrimary color asset to `#A03232`
- keep dark variant consistent with new shade

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ffd72b1888324a87fa0758f1b0834