### PR TITLE
Update primary brand color

### DIFF
--- a/Jeune/Components/FastTimerCardView.swift
+++ b/Jeune/Components/FastTimerCardView.swift
@@ -47,7 +47,14 @@ struct FastTimerCardView: View {
     private var buttonColor: Color {
         switch state {
         case .idle: return .jeunePrimaryColor // deep red
-        case .running: return .jeuneSuccessColor // green
+        case .running: return .jeuneGrayColor // grey when breaking fast
+        }
+    }
+
+    private var buttonTextColor: Color {
+        switch state {
+        case .idle: return .white
+        case .running: return .jeunePrimaryDarkColor
         }
     }
 
@@ -98,6 +105,7 @@ struct FastTimerCardView: View {
             PrimaryCTAButton(
                 title: buttonTitle,
                 background: buttonColor,
+                foreground: buttonTextColor,
                 action: action
             )
             // Horizontal padding removed to allow button to respect card's overall padding

--- a/Jeune/Components/PrimaryCTAButton.swift
+++ b/Jeune/Components/PrimaryCTAButton.swift
@@ -4,13 +4,14 @@ import SwiftUI
 struct PrimaryCTAButton: View {
     var title: String
     var background: Color
+    var foreground: Color = .white
     var action: () -> Void
 
     var body: some View {
         Button(action: action) {
             Text(title)
                 .font(.system(size: 18, weight: .bold))
-                .foregroundColor(.white)
+                .foregroundColor(foreground)
                 .frame(maxWidth: .infinity)
                 .frame(height: DesignConstants.primaryCTAHeight)
                 .background(background)
@@ -20,5 +21,5 @@ struct PrimaryCTAButton: View {
 }
 
 #Preview {
-    PrimaryCTAButton(title: "Start Fasting", background: .jeunePrimaryColor) {}
+    PrimaryCTAButton(title: "Start Fasting", background: .jeunePrimaryColor, foreground: .white) {}
 }

--- a/Jeune/Components/RingView.swift
+++ b/Jeune/Components/RingView.swift
@@ -13,7 +13,7 @@ struct RingView: View {
 
             Circle()
                 .trim(from: 0, to: min(progress, 1))
-                .stroke(progress >= 1.0 ? Color.jeuneSuccessColor : Color.jeunePrimaryDarkColor,
+                .stroke(Color.jeunePrimaryDarkColor,
                         style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
                 .rotationEffect(.degrees(-90))
                 .animation(.easeInOut, value: progress)

--- a/Jeune/Components/ToolbarPlusButtonView.swift
+++ b/Jeune/Components/ToolbarPlusButtonView.swift
@@ -8,7 +8,7 @@ struct ToolbarPlusButtonView: View {
         Button(action: action) {
             Image(systemName: "plus")
                 .font(.system(size: 12, weight: .bold))
-                .foregroundColor(.jeunePrimaryColor)
+                .foregroundColor(.jeunePrimaryDarkColor)
                 .frame(width: DesignConstants.toolbarButtonSize,
                        height: DesignConstants.toolbarButtonSize)
                 .background(Color.jeuneToolbarCircleColor)

--- a/Jeune/Resources/Assets.xcassets/jeunePrimary.colorset/Contents.json
+++ b/Jeune/Resources/Assets.xcassets/jeunePrimary.colorset/Contents.json
@@ -5,9 +5,9 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0x8B",
-          "green" : "0x00",
-          "blue" : "0x00",
+          "red" : "0xA0",
+          "green" : "0x32",
+          "blue" : "0x32",
           "alpha" : "1.000"
         }
       }

--- a/Jeune/Resources/Assets.xcassets/jeunePrimaryDark.colorset/Contents.json
+++ b/Jeune/Resources/Assets.xcassets/jeunePrimaryDark.colorset/Contents.json
@@ -5,9 +5,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0.545",
-          "green": "0.000",
-          "blue": "0.000",
+          "red": "0.627",
+          "green": "0.196",
+          "blue": "0.196",
           "alpha": "1.000"
         }
       }


### PR DESCRIPTION
## Summary
- tweak jeunePrimary color asset to `#A03232`
- keep dark variant consistent with new shade
- adjust fasting ring, CTA button, and toolbar plus icon to use the dark tint
- use grey background when breaking a fast and dark red text

## Testing
- `swift test -q` *(fails: Could not find Package.swift)*
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ffd72b1888324a87fa0758f1b0834