### PR TITLE
Update challenge card and CTA text

### DIFF
--- a/Jeune/Components/ChallengesCardView.swift
+++ b/Jeune/Components/ChallengesCardView.swift
@@ -16,10 +16,11 @@ struct ChallengesCardView: View {
             HStack(spacing: 12) {
                 Image(systemName: "flame.fill")
                     .foregroundColor(.jeunePrimaryColor)
-                    .font(.title2)
+                    .font(.title)
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Join challenges to earn achievements")
                         .font(.subheadline)
+                        .foregroundColor(Color(.lightGray))
                         .lineLimit(2)
                 }
                 Spacer()

--- a/Jeune/Components/FastTimerCardView.swift
+++ b/Jeune/Components/FastTimerCardView.swift
@@ -40,7 +40,7 @@ struct FastTimerCardView: View {
     private var buttonTitle: String {
         switch state {
         case .idle: return "Start Fasting"
-        case .running: return "Break Your Fast"
+        case .running: return "End Fast"
         }
     }
 


### PR DESCRIPTION
## Summary
- change fasting button title to "End Fast"
- make flame icon larger and challenge label light gray

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6840bb55a0048324ad129255e13eb526