### PR TITLE
Adjust challenge card actions

### DIFF
--- a/Jeune/Components/ChallengesCardView.swift
+++ b/Jeune/Components/ChallengesCardView.swift
@@ -9,9 +9,9 @@ struct ChallengesCardView: View {
                     .font(.title3.weight(.semibold))
                 Spacer()
                 Text("SEE ALL")
-                    .font(.caption.weight(.bold))
+                    .font(.system(size: 10, weight: .bold))
                     .foregroundColor(.jeunePrimaryColor)
-            }
+                }
 
             HStack(spacing: 12) {
                 Image(systemName: "flame.fill")
@@ -25,6 +25,7 @@ struct ChallengesCardView: View {
                 Spacer()
                 Image(systemName: "chevron.right")
                     .foregroundColor(.jeunePrimaryColor)
+                    .fontWeight(.bold)
             }
             .padding(.horizontal, 12) // Added horizontal padding inside the gray area
             .frame(height: 76)


### PR DESCRIPTION
## Summary
- use smaller font for "SEE ALL" to match timer pills
- display the chevron with bold weight

## Testing
- `swift test --enable-code-coverage` *(fails: no Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6840bbdc6f9c83249e6ae20e1b7f3218