### PR TITLE
Improve card shadows

### DIFF
--- a/Jeune/Components/ChallengesCardView.swift
+++ b/Jeune/Components/ChallengesCardView.swift
@@ -37,7 +37,12 @@ struct ChallengesCardView: View {
         .frame(maxWidth: .infinity)
         .background(Color.jeuneCardColor)
         .cornerRadius(DesignConstants.cornerRadius)
-        .shadow(color: DesignConstants.cardShadow, radius: 20, y: 2)
+        .shadow(
+            color: DesignConstants.cardShadow,
+            radius: DesignConstants.cardShadowRadius,
+            x: 0,
+            y: 0
+        )
     }
 }
 

--- a/Jeune/Components/FastTimerCardView.swift
+++ b/Jeune/Components/FastTimerCardView.swift
@@ -118,7 +118,12 @@ struct FastTimerCardView: View {
         .frame(maxWidth: .infinity)
         .background(Color.jeuneCardColor)
         .cornerRadius(DesignConstants.cornerRadius)
-        .shadow(color: DesignConstants.cardShadow, radius: 20, y: 2)
+        .shadow(
+            color: DesignConstants.cardShadow,
+            radius: DesignConstants.cardShadowRadius,
+            x: 0,
+            y: 0
+        )
     }
 
     // MARK: – Sub-views

--- a/Jeune/Core/Utilities/DesignConstants.swift
+++ b/Jeune/Core/Utilities/DesignConstants.swift
@@ -5,8 +5,11 @@ enum DesignConstants {
     /// Default corner radius for cards and buttons.
     static let cornerRadius: CGFloat = 20
 
-    /// Shadow used for cards.
+    /// Color used for card shadows.
     static let cardShadow = Color.black.opacity(0.10)
+
+    /// Blur radius for the card shadow. A small value keeps the edge crisp.
+    static let cardShadowRadius: CGFloat = 4
 
     /// Toolbar button size.
     static let toolbarButtonSize: CGFloat = 34


### PR DESCRIPTION
## Summary
- use a smaller blur radius for card shadows
- apply the new shadow style to the timer and challenges cards

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840bc1e5de48324ac010b473e5c4650