### PR TITLE
Update streak badge style

### DIFF
--- a/Jeune/Components/StreakBadgeView.swift
+++ b/Jeune/Components/StreakBadgeView.swift
@@ -7,12 +7,15 @@ struct StreakBadgeView: View {
     var body: some View {
         HStack(spacing: 4) {
             Image(systemName: "checkmark")
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: 8, weight: .semibold))
                 .foregroundColor(.white)
+                .frame(width: 14, height: 14)
+                .background(Color.jeuneSuccessColor)
+                .clipShape(Circle())
 
             Text("\(count)")
                 .font(.system(size: 12))
-                .foregroundColor(.primary)
+                .foregroundColor(.jeuneGrayColor)
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)


### PR DESCRIPTION
## Summary
- tweak StreakBadgeView so the checkmark is inside a circle of `jeuneSuccessColor`
- reduce the checkmark icon size
- render streak count text using the gray palette

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6840bc87ed608324891bfcb9ba5e52f9