### PR TITLE
Adjust toolbar badge and calendar sizing

### DIFF
--- a/Jeune/Components/DayIndicatorView.swift
+++ b/Jeune/Components/DayIndicatorView.swift
@@ -29,23 +29,25 @@ struct DayIndicatorView: View {
 
     var body: some View {
         VStack(spacing: 4) {
+            Text(label)
+                .font(.system(size: 10, weight: .bold))
+                .foregroundColor(state == .selected ? .jeunePrimaryColor : textColor)
+
             ZStack {
+                let strokeWidth: CGFloat = (state == .inactive ? 2 : 4) * 1.25
+                let ringSize = (DesignConstants.miniRingDiameter + 8) * 0.7
+
                 Circle()
-                    .stroke(ringColor, lineWidth: state == .inactive ? 2 : 4)
-                    .frame(width: DesignConstants.miniRingDiameter + 8,
-                           height: DesignConstants.miniRingDiameter + 8)
+                    .stroke(ringColor, lineWidth: strokeWidth)
+                    .frame(width: ringSize, height: ringSize)
 
                 if state == .selected {
                     Circle()
                         .fill(ringColor)
-                        .frame(width: DesignConstants.miniRingDiameter - 4,
-                               height: DesignConstants.miniRingDiameter - 4)
+                        .frame(width: (DesignConstants.miniRingDiameter - 4) * 0.7,
+                               height: (DesignConstants.miniRingDiameter - 4) * 0.7)
                 }
             }
-
-            Text(label)
-                .font(.system(size: 10, weight: .bold))
-                .foregroundColor(state == .selected ? .jeunePrimaryColor : textColor)
         }
     }
 }

--- a/Jeune/Components/StreakBadgeView.swift
+++ b/Jeune/Components/StreakBadgeView.swift
@@ -7,15 +7,15 @@ struct StreakBadgeView: View {
     var body: some View {
         HStack(spacing: 4) {
             Image(systemName: "checkmark")
-                .font(.system(size: 8, weight: .semibold))
+                .font(.system(size: 7, weight: .bold))
                 .foregroundColor(.white)
                 .frame(width: 14, height: 14)
                 .background(Color.jeuneSuccessColor)
                 .clipShape(Circle())
 
             Text("\(count)")
-                .font(.system(size: 12))
-                .foregroundColor(.jeuneGrayColor)
+                .font(.system(size: 8, weight: .bold))
+                .foregroundColor(.jeuneSuccessColor)
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)

--- a/Jeune/Features/JeuneHomeView.swift
+++ b/Jeune/Features/JeuneHomeView.swift
@@ -24,7 +24,7 @@ struct JeuneHomeView: View {
 
                     ChallengesCardView()
                 }
-                .padding(.top, 12)
+                .padding(.top, 4)
                 .padding(.horizontal)
             }
             .background(Color.jeuneCanvasColor.ignoresSafeArea())
@@ -50,7 +50,7 @@ struct JeuneHomeView: View {
     }
 
     private var weekStrip: some View {
-        HStack(spacing: 20) {
+        HStack(spacing: 24) {
             ForEach(0..<7) { index in
                 let date = Calendar.current.date(byAdding: .day, value: index, to: Date())!
                 DayIndicatorView(
@@ -59,7 +59,7 @@ struct JeuneHomeView: View {
                 )
             }
         }
-        .padding(.vertical, 12)
+        .padding(.vertical, 4)
         .frame(maxWidth: .infinity)
     }
 


### PR DESCRIPTION
## Summary
- tweak streak badge styles
- improve day indicator layout
- tighten top spacing on home view

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6840c01e4c5c832488c9a99683dfcf55