### PR TITLE
Align grey colors for fasting ring

### DIFF
--- a/Jeune/Components/FastTimerCardView.swift
+++ b/Jeune/Components/FastTimerCardView.swift
@@ -70,7 +70,7 @@ struct FastTimerCardView: View {
                 // Background track for the ring
                 Circle()
                     .stroke(lineWidth: (DesignConstants.largeRingLineWidth * 0.9) * 0.85)
-                    .foregroundColor(Color.jeuneRingTrackColor) // Color for the track
+                    .foregroundColor(Color.jeuneStatsBGColor) // Match button and capsule grey
                     .frame(width: DesignConstants.largeRingDiameter * 0.8, height: DesignConstants.largeRingDiameter * 0.8)
 
                 RingView(

--- a/Jeune/Components/RingView.swift
+++ b/Jeune/Components/RingView.swift
@@ -9,7 +9,7 @@ struct RingView: View {
     var body: some View {
         ZStack {
             Circle()
-                .stroke(Color.jeuneRingTrackColor, lineWidth: lineWidth)
+                .stroke(Color.jeuneStatsBGColor, lineWidth: lineWidth)
 
             Circle()
                 .trim(from: 0, to: min(progress, 1))


### PR DESCRIPTION
## Summary
- update RingView to use stats background grey
- use same grey on FastTimerCardView ring track

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6840c06235ec8324b51c51576d356e76