### PR TITLE
Add subtle warmth to neutral grays

### DIFF
--- a/Jeune/Resources/Assets.xcassets/jeuneCanvas.colorset/Contents.json
+++ b/Jeune/Resources/Assets.xcassets/jeuneCanvas.colorset/Contents.json
@@ -5,9 +5,9 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.969",
-          "green" : "0.969",
-          "blue" : "0.976",
+          "red" : "0.972",
+          "green" : "0.968",
+          "blue" : "0.975",
           "alpha" : "1.000"
         }
       }

--- a/Jeune/Resources/Assets.xcassets/jeuneStatsBG.colorset/Contents.json
+++ b/Jeune/Resources/Assets.xcassets/jeuneStatsBG.colorset/Contents.json
@@ -5,9 +5,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0.949",
-          "green": "0.949",
-          "blue": "0.961",
+          "red": "0.953",
+          "green": "0.944",
+          "blue": "0.957",
           "alpha": "1.000"
         }
       }

--- a/Jeune/Resources/Assets.xcassets/jeuneToolbarBG.colorset/Contents.json
+++ b/Jeune/Resources/Assets.xcassets/jeuneToolbarBG.colorset/Contents.json
@@ -5,9 +5,9 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0xEF",
-          "green" : "0xEF",
-          "blue" : "0xF1",
+          "red" : "0xF1",
+          "green" : "0xEE",
+          "blue" : "0xF0",
           "alpha" : "1.000"
         }
       }


### PR DESCRIPTION
## Summary
- tweak light canvas color
- warm the stats capsule background
- adjust toolbar plus button fill color

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6840c3add24483248ca0a03ac061b40c