### PR TITLE
Remove duplicate day labels

### DIFF
--- a/Jeune/Components/DayIndicatorView.swift
+++ b/Jeune/Components/DayIndicatorView.swift
@@ -31,7 +31,7 @@ struct DayIndicatorView: View {
         VStack(spacing: 4) {
             Text(label)
                 .font(.system(size: 10, weight: .bold))
-                .foregroundColor(state == .selected ? .jeunePrimaryColor : textColor)
+                .foregroundColor(state == .selected ? .jeunePrimaryDarkColor : textColor)
 
             ZStack {
                 let strokeWidth: CGFloat = (state == .inactive ? 2 : 4) * 1.25
@@ -48,9 +48,6 @@ struct DayIndicatorView: View {
                                height: (DesignConstants.miniRingDiameter - 4) * 0.7)
                 }
             }
-Text(label)
-    .font(.system(size: 10, weight: .bold))
-    .foregroundColor(state == .selected ? .jeunePrimaryDarkColor : textColor)
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove redundant bottom day labels in `DayIndicatorView`
- use primary dark color for selected day text

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6840c3f11690832487fa2ca3ef369609