### PR TITLE
Match gray ring stroke width with colored rings

### DIFF
--- a/Jeune/Components/DayIndicatorView.swift
+++ b/Jeune/Components/DayIndicatorView.swift
@@ -34,7 +34,9 @@ struct DayIndicatorView: View {
                 .foregroundColor(state == .selected ? .jeunePrimaryColor : textColor)
 
             ZStack {
-                let strokeWidth: CGFloat = (state == .inactive ? 2 : 4) * 1.25
+                // Use a consistent stroke width across all states so gray rings
+                // match the thickness of the colored ones.
+                let strokeWidth: CGFloat = 4 * 1.25
                 let ringSize = (DesignConstants.miniRingDiameter + 8) * 0.7
 
                 Circle()


### PR DESCRIPTION
## Summary
- keep `DayIndicatorView` ring stroke width consistent across states

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6840c4183670832496bb1b4706cecd35