### PR TITLE
Adjust fonts for days and challenge section

### DIFF
--- a/Jeune/Components/ChallengesCardView.swift
+++ b/Jeune/Components/ChallengesCardView.swift
@@ -6,7 +6,7 @@ struct ChallengesCardView: View {
         VStack(alignment: .leading, spacing: 16) {
             HStack {
                 Text("Challenges")
-                    .font(.title3.weight(.semibold))
+                    .font(.callout.weight(.semibold))
                 Spacer()
                 Text("SEE ALL")
                     .font(.system(size: 10, weight: .bold))
@@ -19,7 +19,7 @@ struct ChallengesCardView: View {
                     .font(.title)
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Join challenges to earn achievements")
-                        .font(.subheadline)
+                        .font(.callout)
                         .foregroundColor(Color(.lightGray))
                         .lineLimit(2)
                 }

--- a/Jeune/Components/MiniRingView.swift
+++ b/Jeune/Components/MiniRingView.swift
@@ -8,7 +8,7 @@ struct MiniRingView: View {
     var body: some View {
         VStack(spacing: 4) {
             Text(weekday)
-                .font(.caption2.weight(.bold))
+                .font(.system(size: 10, weight: .bold))
                 .foregroundColor(.secondary)
             RingView(
                 progress: progress,


### PR DESCRIPTION
## Summary
- set weekday text to 10pt to match COD sizing
- shrink challenge header and description text for better hierarchy

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840c4e58a1c8324a79fec8aa6a53968