### PR TITLE
Add divider line to fasting ring

### DIFF
--- a/Jeune/Components/FastTimerCardView.swift
+++ b/Jeune/Components/FastTimerCardView.swift
@@ -79,6 +79,11 @@ struct FastTimerCardView: View {
                     lineWidth: (DesignConstants.largeRingLineWidth * 0.9) * 0.85 // Further reduced thickness by 15%
                 )
 
+                // Thin divider that shows the card's background colour
+                Circle()
+                    .stroke(Color.jeuneCardColor, lineWidth: 1)
+                    .frame(width: DesignConstants.largeRingDiameter * 0.8, height: DesignConstants.largeRingDiameter * 0.8)
+
                 centreContent
                 // Removed specific padding; now governed by ZStack's padding
             }


### PR DESCRIPTION
## Summary
- draw a thin card-coloured line to visually split the fasting ring

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6840c912e10c832485c379115a72af0e