### PR TITLE
Add fasting timer demo

### DIFF
--- a/Jeune/Components/FastTimerCardView.swift
+++ b/Jeune/Components/FastTimerCardView.swift
@@ -1,8 +1,10 @@
 import SwiftUI
 
 enum FastTimerState {
-    case idle(days: Int)
-    case running(progress: Double)   // 0.0‒1.0  (fraction of goal completed)
+    /// Idle state showing the time since the last fast in seconds.
+    case idle(seconds: Int)
+    /// Running state with progress fraction 0.0 - 1.0
+    case running(progress: Double)
 }
 
 /// Card displaying the fasting-timer ring and CTA button.
@@ -25,6 +27,9 @@ struct FastTimerCardView: View {
     /// Provide the value using the same `"EEE, HH:mm"` format as `startDate` so
     /// the day of the week can be shown correctly.
     var goalTime: String = "--"
+
+    /// Tapping "EDIT" while idle triggers this action. Optional.
+    var editGoalAction: (() -> Void)? = nil
 
     /// Action for the primary button.
     var action: () -> Void
@@ -135,20 +140,28 @@ struct FastTimerCardView: View {
     @ViewBuilder
     private var centreContent: some View {
         switch state {
-        case .idle(let days):
+        case .idle(let seconds):
             VStack(spacing: 4) {
                 Text("SINCE LAST FAST")
                     .font(.caption.weight(.semibold))
                     .foregroundColor(.secondary)
                     .textCase(.uppercase)
 
-                Text("\(days) days")
-                    .font(.system(size: 52, weight: .heavy))
+                Text(timeString(fromSeconds: seconds))
+                    .font(.system(size: 24, weight: .heavy))
                     .foregroundColor(.jeuneNearBlack)
 
-                Text("EDIT \(goalHours)H GOAL")
-                    .font(.caption.weight(.semibold))
-                    .foregroundColor(.jeunePrimaryDarkColor)
+                if let editAction = editGoalAction {
+                    Button(action: editAction) {
+                        Text("EDIT \(goalHours)H GOAL")
+                            .font(.caption.weight(.semibold))
+                            .foregroundColor(.jeunePrimaryDarkColor)
+                    }
+                } else {
+                    Text("EDIT \(goalHours)H GOAL")
+                        .font(.caption.weight(.semibold))
+                        .foregroundColor(.jeunePrimaryDarkColor)
+                }
             }
 
         case .running(let p):
@@ -244,10 +257,17 @@ struct FastTimerCardView: View {
         let secs = totalSeconds % 60
         return String(format: "%02d:%02d:%02d", hrs, mins, secs)
     }
+
+    private func timeString(fromSeconds seconds: Int) -> String {
+        let hrs = seconds / 3600
+        let mins = (seconds % 3600) / 60
+        let secs = seconds % 60
+        return String(format: "%02d:%02d:%02d", hrs, mins, secs)
+    }
 }
 
 // MARK: – Preview
 #Preview {
-    FastTimerCardView(state: .idle(days: 135)) { }
+    FastTimerCardView(state: .idle(seconds: 3_600)) { }
         .padding()
 }

--- a/Jeune/Features/FastingDemoView.swift
+++ b/Jeune/Features/FastingDemoView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+/// Demo fasting timer that mirrors the design of `FastTimerCardView` but uses
+/// simple in-memory state.
+struct FastingDemoView: View {
+    @State private var isRunning = false
+    @State private var elapsed: Int = 0
+    @State private var sinceLastFast: Int = 7 * 3600 + 25 * 60 + 41
+    @State private var goalHours = 16
+    @State private var showGoalPicker = false
+    @State private var startTime: Date?
+
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        FastTimerCardView(
+            state: isRunning ? .running(progress: progress) : .idle(seconds: sinceLastFast),
+            startDate: startDateString,
+            goalHours: goalHours,
+            goalTime: goalDateString,
+            editGoalAction: { showGoalPicker = true },
+            action: toggleFasting
+        )
+        .sheet(isPresented: $showGoalPicker) {
+            GoalPickerSheet(goalHours: $goalHours)
+        }
+        .onReceive(timer) { _ in
+            if isRunning {
+                elapsed += 1
+            } else {
+                sinceLastFast += 1
+            }
+        }
+    }
+
+    private var progress: Double {
+        guard goalHours > 0 else { return 0 }
+        return min(Double(elapsed) / Double(goalHours * 3600), 1)
+    }
+
+    private var startDateString: String {
+        guard let start = startTime else { return "--" }
+        return format(date: start)
+    }
+
+    private var goalDateString: String {
+        guard let start = startTime else { return "--" }
+        return format(date: start.addingTimeInterval(Double(goalHours) * 3600))
+    }
+
+    private func toggleFasting() {
+        if isRunning {
+            isRunning = false
+            elapsed = 0
+            sinceLastFast = 0
+            startTime = nil
+        } else {
+            isRunning = true
+            elapsed = 0
+            startTime = Date()
+        }
+    }
+
+    private func format(date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "EEE, HH:mm"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f.string(from: date)
+    }
+}
+
+private struct GoalPickerSheet: View {
+    @Binding var goalHours: Int
+    @Environment(\.dismiss) var dismiss
+    private let presets = [16, 18, 20, 24]
+
+    var body: some View {
+        NavigationStack {
+            List(presets, id: \.self) { hours in
+                Button("\(hours) hours") {
+                    goalHours = hours
+                    dismiss()
+                }
+            }
+            .navigationTitle("Select Goal")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    FastingDemoView()
+        .padding()
+}

--- a/Jeune/Features/JeuneHomeView.swift
+++ b/Jeune/Features/JeuneHomeView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct JeuneHomeView: View {
-    @State private var progress: Double = 0.6
     @State private var streak: Int = 3
 
     var body: some View {
@@ -10,18 +9,8 @@ struct JeuneHomeView: View {
                 VStack(spacing: 0) {
                     weekStrip
                         .padding(.bottom, 20)
-
-                    // Updated to use full FastTimerCardView with all props
-                    FastTimerCardView(
-                        state: .running(progress: progress),
-                        startDate: "MON, 09:41",
-                        goalHours: 16,
-                        goalTime: "TUE, 01:41"
-                    ) {
-                        // action placeholder
-                    }
-                    .padding(.bottom, 24)
-
+                        FastingDemoView()
+                        .padding(.bottom, 24)
                     ChallengesCardView()
                 }
                 .padding(.top, 4)

--- a/Jeune/HomePreviewProvider.swift
+++ b/Jeune/HomePreviewProvider.swift
@@ -14,7 +14,7 @@ struct HomePreviewProvider: PreviewProvider {
             .padding()
             
             FastTimerCardView(
-                state: .idle(days: 135),
+                state: .idle(seconds: 26_741),
                 startDate: "--",
                 goalHours: 16,
                 goalTime: "--"


### PR DESCRIPTION
## Summary
- implement `FastingDemoView` showing the original fasting card design
- adjust `FastTimerCardView` to display seconds-based idle time and optional edit action
- update preview provider to use the revised timer component

## Testing
- `swift --version`
- `xcodebuild -list -project Jeune.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840ceb1b04883249051c663e2a62c6b