### PR TITLE
Fix toolbar badge height and adjust fasting label fonts

### DIFF
--- a/Jeune/Components/FastTimerCardView.swift
+++ b/Jeune/Components/FastTimerCardView.swift
@@ -146,7 +146,7 @@ struct FastTimerCardView: View {
         case .idle(let seconds):
             VStack(spacing: 4) {
                 Text("SINCE LAST FAST")
-                    .font(.caption.weight(.semibold))
+                    .font(.system(size: 10, weight: .semibold))
                     .foregroundColor(.secondary)
                     .textCase(.uppercase)
 
@@ -159,12 +159,12 @@ struct FastTimerCardView: View {
                 if let editAction = editGoalAction {
                     Button(action: editAction) {
                         Text("EDIT \(goalHours)H GOAL")
-                            .font(.caption.weight(.semibold))
+                            .font(.system(size: 10, weight: .semibold))
                             .foregroundColor(.jeunePrimaryDarkColor)
                     }
                 } else {
                     Text("EDIT \(goalHours)H GOAL")
-                        .font(.caption.weight(.semibold))
+                        .font(.system(size: 10, weight: .semibold))
                         .foregroundColor(.jeunePrimaryDarkColor)
                 }
             }

--- a/Jeune/Components/StreakBadgeView.swift
+++ b/Jeune/Components/StreakBadgeView.swift
@@ -19,6 +19,7 @@ struct StreakBadgeView: View {
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
+        .frame(height: DesignConstants.toolbarButtonSize)
         .background(Color.jeuneSuccessTintColor)
         .clipShape(Capsule())
     }


### PR DESCRIPTION
## Summary
- match `StreakBadgeView` height with the plus button size
- shrink `SINCE LAST FAST` and edit goal labels to 10pt

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6840d992a0c88324be906eb2d72e93b4