### PR TITLE
Refactor UI helpers

### DIFF
--- a/Jeune/Components/ChallengesCardView.swift
+++ b/Jeune/Components/ChallengesCardView.swift
@@ -9,7 +9,7 @@ struct ChallengesCardView: View {
                     .font(.callout.weight(.semibold))
                 Spacer()
                 Text("SEE ALL")
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.jeuneCaptionBold)
                     .foregroundColor(.jeunePrimaryDarkColor)
                 }
 
@@ -34,17 +34,7 @@ struct ChallengesCardView: View {
             .background(Color(red: 0.94, green: 0.94, blue: 0.95))
             .clipShape(RoundedRectangle(cornerRadius: 20))
         }
-        .padding(.vertical, 16)
-        .padding(.horizontal, 16)
-        .frame(maxWidth: .infinity)
-        .background(Color.jeuneCardColor)
-        .cornerRadius(DesignConstants.cornerRadius)
-        .shadow(
-            color: DesignConstants.cardShadow,
-            radius: DesignConstants.cardShadowRadius,
-            x: 0,
-            y: 0
-        )
+        .jeuneCard()
     }
 }
 

--- a/Jeune/Components/DayIndicatorView.swift
+++ b/Jeune/Components/DayIndicatorView.swift
@@ -29,7 +29,7 @@ struct DayIndicatorView: View {
     var body: some View {
         VStack(spacing: 4) {
             Text(label)
-                .font(.system(size: 10, weight: .bold))
+                .font(.jeuneCaptionBold)
 .foregroundColor(state == .selected ? .jeunePrimaryDarkColor : textColor)
 
             ZStack {

--- a/Jeune/Components/FastTimerCardView.swift
+++ b/Jeune/Components/FastTimerCardView.swift
@@ -36,6 +36,21 @@ struct FastTimerCardView: View {
     /// Action for the primary button.
     var action: () -> Void
 
+    /// Formatter used to parse `startDate` and `goalTime` strings.
+    private static let inputFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "EEE, HH:mm"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+
+    /// Formatter used to display times to the user.
+    private static let outputFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "EEE, h:mm a"
+        return f
+    }()
+
     // MARK: – Derived values
     private var progress: Double {
         switch state {
@@ -102,12 +117,12 @@ struct FastTimerCardView: View {
                 // Titles Row (Outside and above the gray stats capsule)
                 HStack {
                     Text("STARTED")
-                        .font(.system(size: 10, weight: .semibold)) // Changed to 10pt
+                    .font(.jeuneCaption)
                         .foregroundColor(.jeuneGrayColor)
                         .frame(maxWidth: .infinity, alignment: .center)
 
                     Text("\(goalHours)H GOAL")
-                        .font(.system(size: 10, weight: .semibold)) // Changed to 10pt
+                    .font(.jeuneCaption)
                         .foregroundColor(.jeuneGrayColor)
                         .frame(maxWidth: .infinity, alignment: .center)
                 }
@@ -126,16 +141,7 @@ struct FastTimerCardView: View {
             )
             // Horizontal padding removed to allow button to respect card's overall padding
         }
-        .padding(16)
-        .frame(maxWidth: .infinity)
-        .background(Color.jeuneCardColor)
-        .cornerRadius(DesignConstants.cornerRadius)
-        .shadow(
-            color: DesignConstants.cardShadow,
-            radius: DesignConstants.cardShadowRadius,
-            x: 0,
-            y: 0
-        )
+        .jeuneCard()
         .animation(.easeInOut(duration: 0.3), value: state)
     }
 
@@ -146,7 +152,7 @@ struct FastTimerCardView: View {
         case .idle(let seconds):
             VStack(spacing: 4) {
                 Text("SINCE LAST FAST")
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.jeuneCaption)
                     .foregroundColor(.secondary)
                     .textCase(.uppercase)
 
@@ -159,12 +165,12 @@ struct FastTimerCardView: View {
                 if let editAction = editGoalAction {
                     Button(action: editAction) {
                         Text("EDIT \(goalHours)H GOAL")
-                            .font(.system(size: 10, weight: .semibold))
+                            .font(.jeuneCaption)
                             .foregroundColor(.jeunePrimaryDarkColor)
                     }
                 } else {
                     Text("EDIT \(goalHours)H GOAL")
-                        .font(.system(size: 10, weight: .semibold))
+                        .font(.jeuneCaption)
                         .foregroundColor(.jeunePrimaryDarkColor)
                 }
             }
@@ -185,7 +191,7 @@ struct FastTimerCardView: View {
 
     private func valuePill(value: String) -> some View {
         Text(value)
-            .font(.system(size: 10, weight: .bold)) // Changed to 10pt and bold
+            .font(.jeuneCaptionBold)
             .foregroundColor(.jeunePrimaryDarkColor) // Changed to primary color
             .frame(maxWidth: .infinity, alignment: .center)
             .padding(.vertical, 10) // Adjusted for vertical centering in 40pt height
@@ -201,25 +207,10 @@ struct FastTimerCardView: View {
     /// Converts a time string provided in `"EEE, HH:mm"` format to a
     /// user-facing style like `"Mon, 9:30 AM"`.
     private func formatDisplayDateString(from stringValue: String) -> String {
-        print("[Debug] formatDisplayDateString input: '\(stringValue)'")
-        let inputFormatter = DateFormatter()
-        inputFormatter.dateFormat = "EEE, HH:mm"
-        inputFormatter.locale = Locale(identifier: "en_US_POSIX") // For consistent parsing
-
-        guard let date = inputFormatter.date(from: stringValue) else {
-            print("[Debug] Failed to parse date string: '\(stringValue)'")
-            // If parsing fails, return the original string or an error indicator
-            // For example, if the input string is already in the desired format or unexpected
-            // For now, we return the original string to be safe.
-            // Consider logging an error here in a real app.
+        guard let date = Self.inputFormatter.date(from: stringValue) else {
             return stringValue
         }
-
-        let outputFormatter = DateFormatter()
-        outputFormatter.dateFormat = "EEE, h:mm a" // e.g., Mon, 9:41 AM
-        let formattedString = outputFormatter.string(from: date)
-        print("[Debug] Parsed date: \(date), Formatted output: '\(formattedString)'")
-        return formattedString
+        return Self.outputFormatter.string(from: date)
     }
 
     private var statsRow: some View {

--- a/Jeune/Components/MiniRingView.swift
+++ b/Jeune/Components/MiniRingView.swift
@@ -8,7 +8,7 @@ struct MiniRingView: View {
     var body: some View {
         VStack(spacing: 4) {
             Text(weekday)
-                .font(.system(size: 10, weight: .bold))
+                .font(.jeuneCaptionBold)
                 .foregroundColor(.secondary)
             RingView(
                 progress: progress,

--- a/Jeune/Core/Utilities/Font+Jeune.swift
+++ b/Jeune/Core/Utilities/Font+Jeune.swift
@@ -10,6 +10,12 @@ extension Font {
     /// Recommended for card headings, modal titles.
     static let jeuneTitle2: Font = .system(size: 22, weight: .semibold)
 
+    /// Reusable 10pt caption font.
+    static let jeuneCaption: Font = .system(size: 10, weight: .semibold)
+
+    /// Bold variant of `jeuneCaption`.
+    static let jeuneCaptionBold: Font = .system(size: 10, weight: .bold)
+
     // As per tasks.md:
     // - For giant numbers (like timers), consider using .system(size: مناسب_كبير, weight: .regular_or_other, design: .default)
     //   SwiftUI typically selects SF Pro Display for larger sizes automatically.

--- a/Jeune/Core/Utilities/View+Jeune.swift
+++ b/Jeune/Core/Utilities/View+Jeune.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+extension View {
+    /// Applies the standard Jeune card styling to a view.
+    func jeuneCard(padding: CGFloat = 16) -> some View {
+        self
+            .padding(padding)
+            .frame(maxWidth: .infinity)
+            .background(Color.jeuneCardColor)
+            .cornerRadius(DesignConstants.cornerRadius)
+            .shadow(
+                color: DesignConstants.cardShadow,
+                radius: DesignConstants.cardShadowRadius,
+                x: 0,
+                y: 0
+            )
+    }
+}


### PR DESCRIPTION
## Summary
- centralize Jeune card styling with `jeuneCard` view modifier
- extract small caption fonts into `Font+Jeune`
- use new styling and fonts across components
- clean up `FastTimerCardView` with static formatters

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6840dbea72d08324959ee6a94392ad6d