### PR TITLE
Add Gen Plus tab to root menu

### DIFF
--- a/Jeune/Features/RootTab/GenPlus/GenPlusView.swift
+++ b/Jeune/Features/RootTab/GenPlus/GenPlusView.swift
@@ -1,0 +1,28 @@
+// GenPlusView.swift
+import SwiftUI
+
+struct GenPlusView: View {
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                Image(systemName: "star.circle.fill")
+                    .font(.system(size: 80))
+                    .foregroundColor(.jeunePrimaryDarkColor)
+                Text("Gen Plus")
+                    .font(.title2.bold())
+                Text("Subscribe to unlock premium features.")
+                    .font(.body)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding()
+            .navigationTitle("Gen Plus")
+            .background(Color.jeuneCanvasColor.ignoresSafeArea())
+        }
+    }
+}
+
+#Preview {
+    GenPlusView()
+}

--- a/Jeune/Features/RootTab/RootTabView.swift
+++ b/Jeune/Features/RootTab/RootTabView.swift
@@ -30,6 +30,15 @@ struct RootTabView: View {
                             .font(.system(size: 12, weight: .semibold))
                     }
                 }
+
+            GenPlusView()
+                .tabItem {
+                    VStack {
+                        Image(systemName: "star.circle")
+                        Text("Gen Plus")
+                            .font(.system(size: 12, weight: .semibold))
+                    }
+                }
         }
         // Accent the selected tab with a bright orange that matches the logo.
         .accentColor(.orange)


### PR DESCRIPTION
## Summary
- add placeholder GenPlusView to host premium options
- show Gen Plus in the main TabView

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6841502d35608324bb645c9cc09170df