### PR TITLE
Update tab highlight color

### DIFF
--- a/Jeune/Core/Utilities/Color+Jeune.swift
+++ b/Jeune/Core/Utilities/Color+Jeune.swift
@@ -8,6 +8,9 @@ extension Color {
     /// Dark variant of the primary brand colour.
     static let jeunePrimaryDarkColor  = Color("jeunePrimaryDark")
 
+    /// Accent colour used for highlighting the selected tab.
+    static let jeuneAccentColor       = Color("jeuneAccent")
+
     /// Success state accent.
     static let jeuneSuccessColor      = Color("jeuneSuccess")
 

--- a/Jeune/Features/RootTab/RootTabView.swift
+++ b/Jeune/Features/RootTab/RootTabView.swift
@@ -31,7 +31,7 @@ struct RootTabView: View {
                     }
                 }
         }
-        // Accent the selected tab with a bright orange that matches the logo.
-        .accentColor(.orange)
+        // Accent the selected tab with the brand highlight colour.
+        .accentColor(.jeuneAccentColor)
     }
 }

--- a/Jeune/Resources/Assets.xcassets/jeuneAccent.colorset/Contents.json
+++ b/Jeune/Resources/Assets.xcassets/jeuneAccent.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.980",
+          "green" : "0.290",
+          "blue" : "0.224",
+          "alpha" : "1.000"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## Summary
- add new brand accent color asset
- expose `jeuneAccentColor` utility in `Color+Jeune`
- use new accent color for the TabView highlight

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_68415160e08c8324ac086ca05b84bbf3