### PR TITLE
Fix safe area inset error

### DIFF
--- a/Jeune/Core/Utilities/Environment+SafeAreaInsets.swift
+++ b/Jeune/Core/Utilities/Environment+SafeAreaInsets.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import UIKit
+
+private struct SafeAreaInsetsKey: EnvironmentKey {
+    static var defaultValue: EdgeInsets {
+        let insets = UIApplication.shared.firstKeyWindow?.safeAreaInsets ?? .zero
+        return EdgeInsets(top: insets.top, leading: insets.left, bottom: insets.bottom, trailing: insets.right)
+    }
+}
+
+extension EnvironmentValues {
+    /// The current device safe area insets converted to `EdgeInsets`.
+    var safeAreaInsets: EdgeInsets {
+        self[SafeAreaInsetsKey.self]
+    }
+}
+
+private extension UIApplication {
+    var firstKeyWindow: UIWindow? {
+        connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+    }
+}


### PR DESCRIPTION
## Summary
- add custom Environment key to supply safe area insets

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_68415f9c186483248ca176883475b1aa