### PR TITLE
Implement basic profile layout for Me tab

### DIFF
--- a/Jeune/Features/RootTab/Me/MeView.swift
+++ b/Jeune/Features/RootTab/Me/MeView.swift
@@ -5,41 +5,109 @@ import SwiftUI
 struct MeView: View {
     @State private var selectedDate: Date = .init()
 
-    // Placeholder fast data representing fasting duration for each day
-    // in the 7×6 grid shown by ``FastCalendar``.
+    /// Placeholder fast data representing fasting duration for each day
+    /// in the 7×6 grid shown by ``FastCalendar``.
     private var fasts: [Double] = Array(repeating: 0, count: 42)
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 VStack(spacing: 24) {
-                    header
-
+                    toolbar
+                    profileCard
                     FastCalendar(selectedDate: $selectedDate, fasts: fasts)
                 }
                 .padding(.horizontal)
             }
-            .navigationTitle("Me")
+            .background(Color.jeuneCanvasColor.ignoresSafeArea())
+            .navigationBarHidden(true)
         }
     }
 
-    /// The header showing the latest weight and a plus button.
-    private var header: some View {
+    /// Top bar with customisation and settings icons.
+    private var toolbar: some View {
         HStack {
-            VStack(alignment: .leading) {
-                Text("Current weight")
-                    .font(.caption)
-                Text("72 kg")
-                    .font(.title)
-                    .bold()
-            }
+            Image(systemName: "paintbrush")
+                .fontWeight(.bold)
+                .foregroundColor(.jeuneDarkGray)
+
             Spacer()
-            Button(action: { /* add weight action */ }) {
-                Image(systemName: "plus")
-                    .padding(8)
-                    .background(Color.jeunePrimaryDarkColor)
-                    .foregroundColor(.white)
-                    .clipShape(Circle())
+
+            Image(systemName: "gearshape")
+                .fontWeight(.bold)
+                .foregroundColor(.jeuneDarkGray)
+        }
+    }
+
+    /// Card displaying the user's avatar and stats.
+    private var profileCard: some View {
+        VStack(spacing: 12) {
+            Color.clear.frame(height: 40)
+
+            Text("Username")
+                .font(.callout.weight(.semibold))
+
+            statsRow
+        }
+        .padding(.vertical, 16)
+        .jeuneCard()
+        .overlay(alignment: .top) {
+            Image(systemName: "person.crop.circle.fill")
+                .resizable()
+                .scaledToFill()
+                .frame(width: 80, height: 80)
+                .foregroundColor(.jeuneGrayColor)
+                .background(Circle().fill(Color.jeuneGrayColor.opacity(0.2)))
+                .clipShape(Circle())
+                .offset(y: -40)
+        }
+    }
+
+    /// Row showing total fasts, achievements and current streak.
+    private var statsRow: some View {
+        HStack {
+            statBlock(title: "Total Fast", value: "1,000")
+
+            Spacer()
+
+            achievementsBlock
+
+            Spacer()
+
+            statBlock(title: "Current Streak", value: "4")
+        }
+    }
+
+    /// Generic stat block with title and value.
+    private func statBlock(title: String, value: String) -> some View {
+        VStack(spacing: 4) {
+            Text(title.uppercased())
+                .font(.jeuneCaption)
+                .foregroundColor(.jeuneGrayColor)
+            Text(value)
+                .font(.headline.weight(.bold))
+                .foregroundColor(.jeuneNearBlack)
+        }
+    }
+
+    /// Achievements block showing placeholder overlapping icons.
+    private var achievementsBlock: some View {
+        VStack(spacing: 4) {
+            Text("ACHIEVEMENTS")
+                .font(.jeuneCaption)
+                .foregroundColor(.jeuneGrayColor)
+
+            HStack(spacing: -6) {
+                ForEach(0..<3) { _ in
+                    Circle()
+                        .fill(Color.jeunePrimaryDarkColor)
+                        .frame(width: 20, height: 20)
+                }
+
+                Text("+35")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundColor(.jeuneAccentColor)
+                    .padding(.leading, 4)
             }
         }
     }


### PR DESCRIPTION
## Summary
- refactor `MeView` into a custom layout with a toolbar
- add a profile card with avatar and placeholder stats

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_684161f2de6483249e017017b8eb95e4