### PR TITLE
Implement calendar and metrics sections

### DIFF
--- a/Jeune/Core/Utilities/DesignConstants.swift
+++ b/Jeune/Core/Utilities/DesignConstants.swift
@@ -6,10 +6,10 @@ enum DesignConstants {
     static let cornerRadius: CGFloat = 20
 
     /// Color used for card shadows.
-    static let cardShadow = Color.black.opacity(0.10)
+    static let cardShadow = Color.black.opacity(0.15)
 
     /// Blur radius for the card shadow. A small value keeps the edge crisp.
-    static let cardShadowRadius: CGFloat = 4
+    static let cardShadowRadius: CGFloat = 2
 
     /// Toolbar button size.
     static let toolbarButtonSize: CGFloat = 34

--- a/Jeune/Core/Utilities/View+Jeune.swift
+++ b/Jeune/Core/Utilities/View+Jeune.swift
@@ -12,7 +12,7 @@ extension View {
                 color: DesignConstants.cardShadow,
                 radius: DesignConstants.cardShadowRadius,
                 x: 0,
-                y: 0
+                y: 2
             )
     }
 }

--- a/Jeune/Features/RootTab/Me/MeView.swift
+++ b/Jeune/Features/RootTab/Me/MeView.swift
@@ -3,43 +3,216 @@ import SwiftUI
 
 /// Displays user metrics and a heat-map style calendar of recent fasts.
 struct MeView: View {
-    @State private var selectedDate: Date = .init()
-
-    // Placeholder fast data representing fasting duration for each day
-    // in the 7×6 grid shown by ``FastCalendar``.
-    private var fasts: [Double] = Array(repeating: 0, count: 42)
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
-                VStack(spacing: 24) {
-                    header
-
-                    FastCalendar(selectedDate: $selectedDate, fasts: fasts)
+                VStack(spacing: 40) {
+                    toolbar
+                    profileCard
+                    calendarSection
+                    metricsSection
                 }
                 .padding(.horizontal)
             }
-            .navigationTitle("Me")
+            .background(Color.jeuneCanvasColor.ignoresSafeArea())
+            .navigationBarHidden(true)
         }
     }
 
-    /// The header showing the latest weight and a plus button.
-    private var header: some View {
+    /// Top bar with customisation and settings icons.
+    private var toolbar: some View {
         HStack {
-            VStack(alignment: .leading) {
-                Text("Current weight")
-                    .font(.caption)
-                Text("72 kg")
-                    .font(.title)
-                    .bold()
-            }
+            Image(systemName: "paintbrush")
+                .fontWeight(.bold)
+                .foregroundColor(.jeuneDarkGray)
+
             Spacer()
-            Button(action: { /* add weight action */ }) {
-                Image(systemName: "plus")
-                    .padding(8)
-                    .background(Color.jeunePrimaryDarkColor)
-                    .foregroundColor(.white)
-                    .clipShape(Circle())
+
+            Image(systemName: "gearshape")
+                .fontWeight(.bold)
+                .foregroundColor(.jeuneDarkGray)
+        }
+    }
+
+    /// Card displaying the user's avatar and stats.
+    private var profileCard: some View {
+        VStack(spacing: 12) {
+            Color.clear.frame(height: 40)
+
+            Text("Username")
+                .font(.title3.weight(.semibold))
+
+            statsRow
+        }
+        .padding(.vertical, 16)
+        .jeuneCard()
+        .overlay(alignment: .top) {
+            Image(systemName: "person.crop.circle.fill")
+                .resizable()
+                .scaledToFill()
+                .frame(width: 80, height: 80)
+                .foregroundColor(.jeuneGrayColor)
+                .background(Circle().fill(Color.jeuneGrayColor.opacity(0.2)))
+                .clipShape(Circle())
+                .offset(y: -40)
+        }
+    }
+
+    /// Row showing total fasts, achievements and current streak.
+    private var statsRow: some View {
+        HStack {
+            statBlock(title: "Total Fast", value: "1,000")
+
+            Spacer()
+
+            achievementsBlock
+
+            Spacer()
+
+            statBlock(title: "Current Streak", value: "4")
+        }
+    }
+
+    /// Generic stat block with title and value.
+    private func statBlock(title: String, value: String) -> some View {
+        VStack(spacing: 4) {
+            Text(title.uppercased())
+                .font(.jeuneCaptionBold)
+                .foregroundColor(.jeuneGrayColor)
+            Text(value)
+                .font(.title3.weight(.bold))
+                .foregroundColor(.jeuneNearBlack)
+        }
+    }
+
+    /// Achievements block showing placeholder overlapping icons.
+    private var achievementsBlock: some View {
+        VStack(spacing: 4) {
+            Text("ACHIEVEMENTS")
+                .font(.jeuneCaption)
+                .foregroundColor(.jeuneGrayColor)
+
+            HStack(spacing: -6) {
+                ForEach(0..<3) { _ in
+                    Circle()
+                        .fill(Color.jeunePrimaryDarkColor)
+                        .frame(width: 20, height: 20)
+                }
+                Text("+35")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundColor(.jeuneAccentColor)
+                    .padding(.leading, 4)
+            }
+        }
+    }
+
+    private var calendarSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader(title: "Calendar")
+            calendarCard
+        }
+    }
+
+    private var metricsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader(title: "Weekly Metrics", action: "Manage Weight")
+            metricsCard
+        }
+    }
+
+    private func sectionHeader(title: String, action: String = "See All") -> some View {
+        HStack {
+            Text(title)
+                .font(.callout.weight(.semibold))
+            Spacer()
+            Text(action.uppercased())
+                .font(.jeuneCaptionBold)
+                .foregroundColor(.jeunePrimaryDarkColor)
+        }
+    }
+
+    private var calendarCard: some View {
+        VStack(spacing: 16) {
+            weekRow(start: 0)
+            weekRow(start: 7)
+            calendarLegend
+        }
+        .jeuneCard()
+    }
+
+    private func weekRow(start: Int) -> some View {
+        HStack(spacing: 32) {
+            ForEach(0..<7) { index in
+                let date = Calendar.current.date(byAdding: .day, value: start + index, to: Date())!
+                CalendarDayView(date: date, color: calendarColors.randomElement()!)
+            }
+        }
+    }
+
+    private var calendarColors: [Color] {
+        [.jeuneNutritionColor, .jeuneActivityColor, .jeuneRestorationColor, .jeuneSleepColor] 
+    }
+
+    private var calendarLegend: some View {
+        HStack(spacing: 16) {
+            legendItem(color: .jeuneNutritionColor, label: "Nutrition")
+            legendItem(color: .jeuneActivityColor, label: "Activity")
+            legendItem(color: .jeuneRestorationColor, label: "Restoration")
+            legendItem(color: .jeuneSleepColor, label: "Sleep")
+        }
+    }
+
+    private func legendItem(color: Color, label: String) -> some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(color)
+                .frame(width: 8, height: 8)
+            Text(label)
+                .font(.jeuneCaptionBold)
+                .foregroundColor(.jeuneGrayColor)
+        }
+    }
+
+    private var metricsCard: some View {
+        HStack {
+            metricsBlock(title: "Weight", value: "87.5 kg")
+            Spacer()
+            metricsBlock(title: "Avg Fat Burning", value: "2h 30m")
+            Spacer()
+            metricsBlock(title: "Avg Sleep", value: "5h 45m")
+        }
+        .jeuneCard()
+    }
+
+    private func metricsBlock(title: String, value: String) -> some View {
+        VStack(spacing: 4) {
+            Text(title.uppercased())
+                .font(.jeuneCaptionBold)
+                .foregroundColor(.jeuneGrayColor)
+            Text(value)
+                .font(.title3.weight(.bold))
+                .foregroundColor(.jeuneNearBlack)
+        }
+    }
+
+    private struct CalendarDayView: View {
+        var date: Date
+        var color: Color
+
+        private var dayString: String {
+            let f = DateFormatter()
+            f.dateFormat = "d"
+            return f.string(from: date)
+        }
+
+        var body: some View {
+            VStack(spacing: 4) {
+                Text(dayString)
+                    .font(.jeuneCaptionBold)
+                Circle()
+                    .stroke(color, lineWidth: 4)
+                    .frame(width: 26, height: 26)
             }
         }
     }


### PR DESCRIPTION
## Summary
- update card shadow constants to match Explore header
- add calendar and metrics sections to Me tab
- tweak fonts and spacing in profile card

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_684161f2de6483249e017017b8eb95e4