### PR TITLE
Fix safeAreaInsets errors

### DIFF
--- a/Jeune/Core/Utilities/EnvironmentValues+SafeAreaInsets.swift
+++ b/Jeune/Core/Utilities/EnvironmentValues+SafeAreaInsets.swift
@@ -1,0 +1,22 @@
+// EnvironmentValues+SafeAreaInsets.swift
+import SwiftUI
+
+private struct SafeAreaInsetsKey: EnvironmentKey {
+    static var defaultValue: EdgeInsets {
+#if os(iOS)
+        let insets = UIApplication.shared.connectedScenes
+            .compactMap { ($0 as? UIWindowScene)?.keyWindow?.safeAreaInsets }
+            .first ?? .zero
+        return EdgeInsets(top: insets.top, leading: insets.left, bottom: insets.bottom, trailing: insets.right)
+#else
+        return EdgeInsets()
+#endif
+    }
+}
+
+extension EnvironmentValues {
+    var safeAreaInsets: EdgeInsets {
+        get { self[SafeAreaInsetsKey.self] }
+        set { self[SafeAreaInsetsKey.self] = newValue }
+    }
+}


### PR DESCRIPTION
## Summary
- define safeAreaInsets environment value when running on iOS

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_684161fc0a6c8324905e23c721f694a3