### PR TITLE
Fix safeAreaInsets redeclaration

### DIFF
--- a/Jeune/Core/Utilities/EnvironmentValues+SafeAreaInsets.swift
+++ b/Jeune/Core/Utilities/EnvironmentValues+SafeAreaInsets.swift
@@ -1,0 +1,22 @@
+// EnvironmentValues+SafeAreaInsets.swift
+import SwiftUI
+
+private struct JeuneSafeAreaInsetsKey: EnvironmentKey {
+    static var defaultValue: EdgeInsets {
+#if os(iOS)
+        let insets = UIApplication.shared.connectedScenes
+            .compactMap { ($0 as? UIWindowScene)?.keyWindow?.safeAreaInsets }
+            .first ?? .zero
+        return EdgeInsets(top: insets.top, leading: insets.left, bottom: insets.bottom, trailing: insets.right)
+#else
+        return EdgeInsets()
+#endif
+    }
+}
+
+extension EnvironmentValues {
+    var jeuneSafeAreaInsets: EdgeInsets {
+        get { self[JeuneSafeAreaInsetsKey.self] }
+        set { self[JeuneSafeAreaInsetsKey.self] = newValue }
+    }
+}

--- a/Jeune/Features/RootTab/Explore/ExploreView.swift
+++ b/Jeune/Features/RootTab/Explore/ExploreView.swift
@@ -11,7 +11,7 @@ struct ExploreView: View {
     @State private var selectedSegment: ExploreSegment = .home
 
 
-    @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
+    @Environment(\.jeuneSafeAreaInsets) private var safeAreaInsets: EdgeInsets
 
 
     /// Approximate height of the custom header including the safe area.
@@ -82,7 +82,7 @@ private enum ExploreSegment: String, CaseIterable {
 private struct ExploreHeaderView: View {
     @Binding var selected: ExploreSegment
 
-    @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
+    @Environment(\.jeuneSafeAreaInsets) private var safeAreaInsets: EdgeInsets
 
 
     var body: some View {


### PR DESCRIPTION
## Summary
- rename environment value to avoid conflict with SwiftUI's `safeAreaInsets`
- update explore view to use `jeuneSafeAreaInsets`

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_684161fc0a6c8324905e23c721f694a3