### PR TITLE
Adjust layout and font weights

### DIFF
--- a/Jeune/Features/RootTab/Explore/ExploreView.swift
+++ b/Jeune/Features/RootTab/Explore/ExploreView.swift
@@ -27,7 +27,13 @@ struct ExploreView: View {
                     Color.clear
                         .frame(height: headerHeight)
 
-                    FeaturedBannerView()
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("FEATURED")
+                            .font(.callout.weight(.semibold))
+                            .foregroundColor(.jeuneNearBlack)
+
+                        FeaturedBannerView()
+                    }
                 }
                 .padding(.horizontal)
                 .padding(.bottom, 16)
@@ -86,17 +92,18 @@ private struct ExploreHeaderView: View {
 
 
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: 9) {
             HStack {
                 Image(systemName: "magnifyingglass")
-                    .fontWeight(.bold)
+                    .font(.system(size: 18, weight: .bold))
                     .foregroundColor(.jeuneDarkGray)
                 Spacer()
                 Text("Explore")
-                    .font(.callout.weight(.bold))
+                    .font(.callout.weight(.semibold))
                     .foregroundColor(.jeuneNearBlack)
                 Spacer()
                 Image(systemName: "bookmark")
+                    .font(.system(size: 18, weight: .bold))
                     .foregroundColor(.jeuneDarkGray)
             }
 
@@ -115,7 +122,7 @@ private struct ExploreHeaderView: View {
                 }
             }
         }
-        .padding(.top, safeAreaInsets.top + 8)
+        .padding(.top, safeAreaInsets.top + 4)
         .padding(.horizontal)
         .padding(.bottom, 12)
         .frame(maxWidth: .infinity)

--- a/Jeune/Features/RootTab/Me/MeView.swift
+++ b/Jeune/Features/RootTab/Me/MeView.swift
@@ -42,7 +42,7 @@ struct MeView: View {
 
     /// Card displaying the user's avatar and stats.
     private var profileCard: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 8) {
             Color.clear.frame(height: 40)
 
             Text("Username")
@@ -67,8 +67,8 @@ struct MeView: View {
     /// Row showing total fasts, achievements and current streak.
     private var statsRow: some View {
         HStack {
+            Spacer()
             statBlock(title: "Total Fast", value: "1,000")
-
 
             Spacer()
 
@@ -76,8 +76,8 @@ struct MeView: View {
 
             Spacer()
 
-
             statBlock(title: "Current Streak", value: "4")
+            Spacer()
         }
     }
 
@@ -85,7 +85,7 @@ struct MeView: View {
     private func statBlock(title: String, value: String) -> some View {
         VStack(spacing: 4) {
             Text(title.uppercased())
-                .font(.jeuneCaptionBold)
+                .font(.jeuneCaption)
                 .foregroundColor(.jeuneGrayColor)
             Text(value)
                 .font(.title3.weight(.bold))
@@ -199,7 +199,7 @@ struct MeView: View {
     private func metricsBlock(title: String, value: String) -> some View {
         VStack(spacing: 4) {
             Text(title.uppercased())
-                .font(.jeuneCaptionBold)
+                .font(.jeuneCaption)
                 .foregroundColor(.jeuneGrayColor)
             Text(value)
                 .font(.title3.weight(.bold))


### PR DESCRIPTION
## Summary
- tweak Explore header spacing and icon size
- add 'Featured' label above the banner
- reduce avatar spacing in Me screen
- center stats row and adjust metric fonts

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project Jeune.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684172a2a69883249ea3d7473b024b36