### PR TITLE
Fix premium tab label and icon

### DIFF
--- a/Jeune/Features/RootTab/GenPlus/GenPlusView.swift
+++ b/Jeune/Features/RootTab/GenPlus/GenPlusView.swift
@@ -5,10 +5,10 @@ struct GenPlusView: View {
     var body: some View {
         NavigationStack {
             VStack(spacing: 16) {
-                Image(systemName: "star.circle.fill")
+                Image(systemName: "flame.fill")
                     .font(.system(size: 80))
                     .foregroundColor(.jeunePrimaryDarkColor)
-                Text("Gen Plus")
+                Text("Jeune+")
                     .font(.title2.bold())
                 Text("Subscribe to unlock premium features.")
                     .font(.body)
@@ -17,7 +17,7 @@ struct GenPlusView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .padding()
-            .navigationTitle("Gen Plus")
+            .navigationTitle("Jeune+")
             .background(Color.jeuneCanvasColor.ignoresSafeArea())
         }
     }

--- a/Jeune/Features/RootTab/RootTabView.swift
+++ b/Jeune/Features/RootTab/RootTabView.swift
@@ -34,8 +34,8 @@ struct RootTabView: View {
             GenPlusView()
                 .tabItem {
                     VStack {
-                        Image(systemName: "star.circle")
-                        Text("Gen Plus")
+                        Image(systemName: "flame")
+                        Text("Jeune+")
                             .font(.system(size: 12, weight: .semibold))
                     }
                 }


### PR DESCRIPTION
## Summary
- rename the Gen+ tab to **Jeune+** and use flame icon
- update the premium upsell view with Jeune+ copy and flame symbol

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_684172d64cd08324b0522a7a9da1049b