### PR TITLE
Fix home top spacing

### DIFF
--- a/Jeune/Features/JeuneHomeView.swift
+++ b/Jeune/Features/JeuneHomeView.swift
@@ -9,11 +9,12 @@ struct JeuneHomeView: View {
                 VStack(spacing: 0) {
                     weekStrip
                         .padding(.bottom, 20)
-                        FastingDemoView()
+                    FastingDemoView()
                         .padding(.bottom, 24)
                     ChallengesCardView()
                 }
-                .padding(.top, 4)
+                // Remove extra top padding so the week strip sits closer to the
+                // toolbar.
                 .padding(.horizontal)
             }
             .background(Color.jeuneCanvasColor.ignoresSafeArea())
@@ -26,7 +27,8 @@ struct JeuneHomeView: View {
                     Image("logojeune")
                         .resizable()
                         .scaledToFit()
-                        .frame(height: 100) // Adjust height as needed, aiming for good proportion across devices
+                        // Smaller height keeps the navigation bar compact
+                        .frame(height: 60)
                 }
 
                 ToolbarItem(placement: .navigationBarTrailing) {


### PR DESCRIPTION
## Summary
- tighten spacing between navigation bar and week strip on home screen
- shrink app bar logo height for a more compact layout

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841732cede483249f2e6c4a9918b035