### PR TITLE
Adjust explore header spacing

### DIFF
--- a/Jeune/Features/RootTab/Explore/ExploreView.swift
+++ b/Jeune/Features/RootTab/Explore/ExploreView.swift
@@ -15,8 +15,9 @@ struct ExploreView: View {
 
 
     /// Approximate height of the custom header including the safe area.
+    /// Reduced constant to remove excess spacing under the notch.
     private var headerHeight: CGFloat {
-        safeAreaInsets.top + 112
+        safeAreaInsets.top + 96
     }
 
     var body: some View {
@@ -94,7 +95,7 @@ private struct ExploreHeaderView: View {
     var body: some View {
 
         // Increased spacing to better separate rows
-        VStack(spacing: 14) {
+        VStack(spacing: 18) {
 
             HStack {
                 Image(systemName: "magnifyingglass")


### PR DESCRIPTION
## Summary
- reduce offset space before Explore header
- add more vertical space between header title and menu items

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_68417b38d39c83248fbac156e09f25b8