### PR TITLE
Improve segmented menu animation

### DIFF
--- a/Jeune/Features/RootTab/Explore/ExploreView.swift
+++ b/Jeune/Features/RootTab/Explore/ExploreView.swift
@@ -9,6 +9,11 @@ struct ExploreView: View {
 
     /// Currently selected segment in the segmented menu.
     @State private var selectedSegment: ExploreSegment = .home
+    /// Previously selected segment used to determine sweep direction.
+    @State private var previousSegment: ExploreSegment = .home
+    /// Direction that controls the slide transition between segment views.
+    @State private var forwardTransition: Bool = true
+    @Namespace private var segmentNamespace
 
 
     @Environment(\.jeuneSafeAreaInsets) private var safeAreaInsets: EdgeInsets
@@ -20,6 +25,29 @@ struct ExploreView: View {
         safeAreaInsets.top + 96
     }
 
+    /// Transition used for sweeping in the selected segment's content.
+    private var sweepTransition: AnyTransition {
+        if forwardTransition {
+            return .asymmetric(insertion: .move(edge: .trailing),
+                               removal: .move(edge: .leading))
+        } else {
+            return .asymmetric(insertion: .move(edge: .leading),
+                               removal: .move(edge: .trailing))
+        }
+    }
+
+    /// Updates the direction for the transition based on the newly selected segment.
+    private func updateTransitionDirection(for newValue: ExploreSegment) {
+        let cases = ExploreSegment.allCases
+        if let newIndex = cases.firstIndex(of: newValue),
+           let oldIndex = cases.firstIndex(of: previousSegment) {
+            forwardTransition = newIndex > oldIndex
+        } else {
+            forwardTransition = true
+        }
+        previousSegment = newValue
+    }
+
     var body: some View {
         NavigationStack {
             ScrollView {
@@ -28,13 +56,12 @@ struct ExploreView: View {
                     Color.clear
                         .frame(height: headerHeight)
 
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("FEATURED")
-                            .font(.callout.weight(.semibold))
-                            .foregroundColor(.jeuneNearBlack)
-
-                        FeaturedBannerView()
+                    ZStack {
+                        if selectedSegment == .home { homeContent.transition(sweepTransition) }
+                        if selectedSegment == .learn { learnContent.transition(sweepTransition) }
+                        if selectedSegment == .challenges { challengesContent.transition(sweepTransition) }
                     }
+                    .animation(.spring(response: 0.35, dampingFraction: 0.75), value: selectedSegment)
                 }
                 .padding(.horizontal)
                 .padding(.bottom, 16)
@@ -42,8 +69,43 @@ struct ExploreView: View {
             .background(Color.jeuneCanvasColor.ignoresSafeArea())
             .navigationBarHidden(true)
             .overlay(alignment: .top) {
-                ExploreHeaderView(selected: $selectedSegment)
+                ExploreHeaderView(selected: $selectedSegment, animation: segmentNamespace)
             }
+            .onChange(of: selectedSegment) { newValue in
+                updateTransitionDirection(for: newValue)
+            }
+        }
+    }
+
+    private var homeContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("FEATURED")
+                .font(.callout.weight(.semibold))
+                .foregroundColor(.jeuneNearBlack)
+
+            FeaturedBannerView()
+        }
+    }
+
+    private var learnContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("ARTICLES")
+                .font(.callout.weight(.semibold))
+                .foregroundColor(.jeuneNearBlack)
+
+            ForEach(viewModel.filteredArticles) { article in
+                ArticleRow(article: article)
+            }
+        }
+    }
+
+    private var challengesContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("CHALLENGES")
+                .font(.callout.weight(.semibold))
+                .foregroundColor(.jeuneNearBlack)
+
+            ChallengesCardView()
         }
     }
 }
@@ -88,6 +150,7 @@ private enum ExploreSegment: String, CaseIterable {
 /// Fixed header containing toolbar actions and the segmented menu.
 private struct ExploreHeaderView: View {
     @Binding var selected: ExploreSegment
+    var animation: Namespace.ID
 
     @Environment(\.jeuneSafeAreaInsets) private var safeAreaInsets: EdgeInsets
 
@@ -119,10 +182,20 @@ private struct ExploreHeaderView: View {
                         .padding(.vertical, 6)
                         .frame(maxWidth: .infinity)
                         .background(
-                            Capsule()
-                                .fill(selected == segment ? Color.jeuneAccentColor.opacity(0.15) : Color.clear)
+                            ZStack {
+                                if selected == segment {
+                                    Capsule()
+                                        .fill(Color.jeuneAccentColor.opacity(0.15))
+                                        .matchedGeometryEffect(id: "SEGMENT_BUBBLE", in: animation)
+                                }
+                            }
                         )
-                        .onTapGesture { selected = segment }
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
+                                selected = segment
+                            }
+                        }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- enable smooth bubble animation for ExploreView segmented menu
- swap segment content based on selected tab
- show challenges card under Challenges segment
- add sweeping transition matching segment direction

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_68417f2ac9fc83248e243f34368f60a3