### PR TITLE
Fix Me menu header animation

### DIFF
--- a/Jeune/Features/RootTab/Me/MeView.swift
+++ b/Jeune/Features/RootTab/Me/MeView.swift
@@ -10,7 +10,6 @@ struct MeView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 40) {
-                    toolbar
                     profileCard
                     calendarSection
                     metricsSection
@@ -29,24 +28,7 @@ struct MeView: View {
             }
             .background(Color.jeuneCanvasColor.ignoresSafeArea())
             .navigationBarHidden(true)
-            .overlay(alignment: .top) { appBar.opacity(showHeader ? 1 : 0) }
-        }
-    }
-
-    /// Top bar with customisation and settings icons.
-    private var toolbar: some View {
-        HStack {
-            Image(systemName: "paintbrush")
-                .fontWeight(.bold)
-                .foregroundColor(.jeuneDarkGray)
-
-
-            Spacer()
-
-
-            Image(systemName: "gearshape")
-                .fontWeight(.bold)
-                .foregroundColor(.jeuneDarkGray)
+            .overlay(alignment: .top) { appBar }
         }
     }
 
@@ -226,7 +208,9 @@ struct MeView: View {
         }
     }
 
-    /// Floating app bar that appears when scrolling up past the username.
+    /// Floating app bar that transitions from transparent to solid when
+    /// scrolling past the username. The paintbrush and gear icons remain
+    /// visible at all times.
     private var appBar: some View {
         HStack {
             Image(systemName: "paintbrush")
@@ -238,6 +222,7 @@ struct MeView: View {
             Text("Username")
                 .font(.callout.weight(.semibold))
                 .foregroundColor(.jeuneNearBlack)
+                .opacity(showHeader ? 1 : 0)
 
             Spacer()
 
@@ -249,8 +234,17 @@ struct MeView: View {
         .padding(.horizontal)
         .padding(.bottom, 12)
         .frame(maxWidth: .infinity)
-        .background(Color.white.ignoresSafeArea(edges: .top))
-        .shadow(color: Color.black.opacity(0.15), radius: 2, x: 0, y: 2)
+        .background(
+            Color.white
+                .opacity(showHeader ? 1 : 0)
+                .ignoresSafeArea(edges: .top)
+        )
+        .shadow(
+            color: Color.black.opacity(showHeader ? 0.15 : 0),
+            radius: 2,
+            x: 0,
+            y: 2
+        )
     }
 
     /// Preference key for tracking the Y position of the username.


### PR DESCRIPTION
## Summary
- keep header icons pinned at the top
- fade in the username and app bar background when scrolled

## Testing
- `swiftc Jeune/Features/RootTab/Me/MeView.swift -o /tmp/meview` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_b_68419269689c8324b8e025087a336a43