### PR TITLE
Implement explore challenges list

### DIFF
--- a/Jeune/Features/RootTab/Explore/Challenge.swift
+++ b/Jeune/Features/RootTab/Explore/Challenge.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct Challenge: Identifiable {
+    let id = UUID()
+    let tag: String
+    let title: String
+    let duration: String
+    let participants: String
+    let image: String
+}
+
+#if DEBUG
+extension Challenge {
+    static let sampleChallenges: [Challenge] = [
+        Challenge(tag: "Fasting", title: "7 Day Fasting Streak", duration: "7 days", participants: "300k active", image: "flame.fill"),
+        Challenge(tag: "Fasting", title: "14 Day Intermittent Fast", duration: "14 days", participants: "250k active", image: "flame.fill"),
+        Challenge(tag: "Fasting", title: "21 Day Cleanse", duration: "21 days", participants: "120k active", image: "drop.fill"),
+        Challenge(tag: "Fasting", title: "30 Day Keto Fast", duration: "30 days", participants: "75k active", image: "leaf.fill"),
+        Challenge(tag: "Fasting", title: "4x16 Hour Streak", duration: "4x16h", participants: "110k active", image: "timer"),
+        Challenge(tag: "Fasting", title: "4x20 Hour Streak", duration: "4x20h", participants: "90k active", image: "timer"),
+        Challenge(tag: "Fasting", title: "2x36 Hour Push", duration: "2x36h", participants: "80k active", image: "bolt.fill"),
+        Challenge(tag: "Fasting", title: "Weekend Warrior", duration: "2 days", participants: "140k active", image: "sun.min"),
+        Challenge(tag: "Fasting", title: "Lean Up Month", duration: "1 month", participants: "60k active", image: "hare.fill"),
+        Challenge(tag: "Fasting", title: "3 Month Transformation", duration: "3 months", participants: "45k active", image: "sparkles")
+    ]
+}
+#endif

--- a/Jeune/Features/RootTab/Explore/ChallengeBannerView.swift
+++ b/Jeune/Features/RootTab/Explore/ChallengeBannerView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// Banner promoting the featured challenge.
+struct ChallengeBannerView: View {
+    var body: some View {
+        HStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("CHALLENGE")
+                    .font(.caption.weight(.bold))
+                    .foregroundColor(Color.white.opacity(0.7))
+
+                Text("Three Month Fasting Challenge")
+                    .font(.headline.weight(.bold))
+                    .foregroundColor(.white)
+
+                Button(action: {}) {
+                    Text("Join Now")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundColor(.white)
+                        .padding(.vertical, 6)
+                        .padding(.horizontal, 16)
+                        .background(Color.jeunePrimaryDarkColor)
+                        .clipShape(Capsule())
+                }
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Rectangle()
+                .fill(Color.orange)
+                .frame(maxWidth: .infinity)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 150)
+        .background(Color.jeunePrimaryDarkColor)
+        .cornerRadius(DesignConstants.cornerRadius)
+    }
+}
+
+#Preview {
+    ChallengeBannerView()
+        .padding()
+}

--- a/Jeune/Features/RootTab/Explore/ChallengeRow.swift
+++ b/Jeune/Features/RootTab/Explore/ChallengeRow.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct ChallengeRow: View {
+    let challenge: Challenge
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: challenge.image)
+                .frame(width: 40, height: 40)
+                .foregroundColor(.jeunePrimaryDarkColor)
+                .background(Circle().fill(Color.jeuneGrayColor.opacity(0.2)))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(challenge.tag.uppercased())
+                    .font(.caption2)
+                    .foregroundColor(.jeuneSuccessColor)
+                Text(challenge.title)
+                    .font(.headline)
+                    .foregroundColor(.jeuneNearBlack)
+                    .lineLimit(1)
+                Text("\(challenge.duration) \u{2022} \(challenge.participants)")
+                    .font(.footnote)
+                    .foregroundColor(.jeuneGrayColor)
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .foregroundColor(.jeuneGrayColor)
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+#Preview {
+    ChallengeRow(challenge: Challenge.sampleChallenges.first!)
+        .padding()
+}

--- a/Jeune/Features/RootTab/Explore/ExploreView.swift
+++ b/Jeune/Features/RootTab/Explore/ExploreView.swift
@@ -21,10 +21,15 @@ struct ExploreView: View {
     @Environment(\.jeuneSafeAreaInsets) private var safeAreaInsets: EdgeInsets
 
 
+    /// Padding applied to the header. Removing a small amount keeps the
+    /// toolbar consistent with the rest of the app.
+    private var headerTopPadding: CGFloat {
+        max(0, safeAreaInsets.top - 6)
+    }
+
     /// Approximate height of the custom header including the safe area.
-    /// Reduced constant to remove excess spacing under the notch.
     private var headerHeight: CGFloat {
-        safeAreaInsets.top + 85
+        headerTopPadding + 85
     }
 
 
@@ -119,11 +124,30 @@ struct ExploreView: View {
 
     private var challengesContent: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("CHALLENGES")
+            Text("FEATURED")
                 .font(.callout.weight(.semibold))
                 .foregroundColor(.jeuneNearBlack)
 
-            ChallengesCardView()
+            ChallengeBannerView()
+
+            Text("JOIN A CHALLENGE")
+                .font(.callout.weight(.semibold))
+                .foregroundColor(.jeuneNearBlack)
+                .padding(.top, 4)
+
+            VStack(spacing: 0) {
+                ForEach(Challenge.sampleChallenges) { challenge in
+                    NavigationLink(destination: Text(challenge.title)) {
+                        ChallengeRow(challenge: challenge)
+                    }
+
+                    if challenge.id != Challenge.sampleChallenges.last?.id {
+                        Divider()
+                            .background(Color.jeuneGrayColor.opacity(0.3))
+                    }
+                }
+            }
+            .jeuneCard(padding: 0)
         }
     }
 }
@@ -221,7 +245,7 @@ private struct ExploreHeaderView: View {
         }
 
         // Remove extra offset to tighten space below the notch
-        .padding(.top, safeAreaInsets.top)
+        .padding(.top, max(0, safeAreaInsets.top - 6))
 
         .padding(.horizontal)
         .padding(.bottom, 12)


### PR DESCRIPTION
## Summary
- refine header spacing on ExploreView
- add sample challenge models and row view
- show a banner and list of challenges in the Explore tab

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6841a846395083248f5b885f27bda93f