### PR TITLE
Update challenge navigation and explore cards

### DIFF
--- a/Jeune/Components/ChallengeCardView.swift
+++ b/Jeune/Components/ChallengeCardView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+/// Small vertical card used in the Explore home section.
+struct ChallengeCardView: View {
+    let challenge: Challenge
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Image(challenge.image)
+                .resizable()
+                .scaledToFit()
+                .frame(height: 80)
+                .frame(maxWidth: .infinity)
+
+            Text(challenge.tag.uppercased())
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(.jeuneSuccessColor)
+
+            Text(challenge.title)
+                .font(.footnote.weight(.semibold))
+                .foregroundColor(.jeuneNearBlack)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text("\(challenge.duration) \u{2022} \(challenge.participants)")
+                .font(.caption2)
+                .foregroundColor(.jeuneGrayColor)
+        }
+        .padding(12)
+        .frame(width: 170, alignment: .leading)
+        .background(Color.jeuneCardColor)
+        .cornerRadius(DesignConstants.cornerRadius)
+        .shadow(color: DesignConstants.cardShadow,
+                radius: DesignConstants.cardShadowRadius,
+                x: 0,
+                y: 2)
+    }
+}
+
+#Preview {
+    ChallengeCardView(challenge: Challenge.sampleChallenges.first!)
+        .padding()
+}

--- a/Jeune/Components/ChallengesCardView.swift
+++ b/Jeune/Components/ChallengesCardView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 /// Placeholder card showing upcoming challenges section.
 struct ChallengesCardView: View {
+    var seeAllAction: () -> Void = {}
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack {
@@ -9,10 +11,13 @@ struct ChallengesCardView: View {
                     .font(.callout.weight(.semibold))
                     .padding(.leading, 4)
                 Spacer()
-                Text("SEE ALL")
-                    .font(.jeuneCaptionBold)
-                    .foregroundColor(.jeunePrimaryDarkColor)
+                Button(action: seeAllAction) {
+                    Text("SEE ALL")
+                        .font(.jeuneCaptionBold)
+                        .foregroundColor(.jeunePrimaryDarkColor)
                 }
+                .buttonStyle(PlainButtonStyle())
+            }
 
             HStack(spacing: 12) {
                 Image(systemName: "flame.fill")

--- a/Jeune/Core/Models/AppState.swift
+++ b/Jeune/Core/Models/AppState.swift
@@ -2,12 +2,26 @@
 import SwiftUI
 import Combine
 
+/// Tabs available in ``RootTabView``.
+enum RootTab: Hashable {
+    case today
+    case explore
+    case me
+    case plus
+}
+
 class AppState: ObservableObject {
     // Placeholder for global app state properties
     // e.g., @Published var currentUser: UserProfile?
 
     /// Indicates if the onboarding flow has been completed.
     @Published var onboardingCompleted: Bool = false
+
+    /// Currently selected tab in ``RootTabView``.
+    @Published var selectedTab: RootTab = .today
+
+    /// Selected segment in ``ExploreView``.
+    @Published var exploreSegment: ExploreSegment = .home
 
     init() {
         // Initialize state

--- a/Jeune/Core/Models/ExploreSegment.swift
+++ b/Jeune/Core/Models/ExploreSegment.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Segments that can be selected in ``ExploreView``.
+enum ExploreSegment: String, CaseIterable {
+    case home = "Home"
+    case learn = "Learn"
+    case challenges = "Challenges"
+}

--- a/Jeune/Features/FastingDemoView.swift
+++ b/Jeune/Features/FastingDemoView.swift
@@ -104,15 +104,18 @@ private struct GoalPickerSheet: View {
     var body: some View {
         VStack(spacing: 0) {
             HStack {
-                Text("Change Fast Goal")
-                    .font(.subheadline)
-                    .foregroundColor(.black)
-                Spacer()
                 Button(action: { dismiss() }) {
                     Image(systemName: "xmark")
+                        .font(.system(size: 16, weight: .bold))
                         .foregroundColor(.black)
                 }
+                Spacer()
             }
+            .overlay(
+                Text("Change Fast Goal")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(.black)
+            )
             .padding()
 
             Divider()

--- a/Jeune/Features/JeuneHomeView.swift
+++ b/Jeune/Features/JeuneHomeView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct JeuneHomeView: View {
     @State private var streak: Int = 3
+    @EnvironmentObject private var appState: AppState
 
     var body: some View {
         NavigationStack {
@@ -11,7 +12,7 @@ struct JeuneHomeView: View {
                         .padding(.bottom, 20)
                     FastingDemoView()
                         .padding(.bottom, 24)
-                    ChallengesCardView()
+                    ChallengesCardView(seeAllAction: navigateToChallenges)
                 }
                 // Remove extra top padding so the week strip sits closer to the
                 // toolbar.
@@ -65,6 +66,11 @@ HStack(spacing: 32) {
         if index == 0 { return .selected }
         if index == 6 { return .completed }
         return .inactive
+    }
+
+    private func navigateToChallenges() {
+        appState.selectedTab = .explore
+        appState.exploreSegment = .challenges
     }
 }
 

--- a/Jeune/Features/RootTab/Explore/ExploreView.swift
+++ b/Jeune/Features/RootTab/Explore/ExploreView.swift
@@ -6,6 +6,8 @@ struct ExploreView: View {
 
     @Environment(\.openURL) private var openURL: OpenURLAction
 
+    @EnvironmentObject private var appState: AppState
+
 
     /// Currently selected segment in the segmented menu.
     @State private var selectedSegment: ExploreSegment = .home
@@ -88,13 +90,17 @@ struct ExploreView: View {
                 ExploreHeaderView(selected: $selectedSegment, animation: segmentNamespace)
 
             }
-            .onChange(of: selectedSegment) { newValue in
-                updateTransitionDirection(for: newValue)
-
+            .onAppear {
+                selectedSegment = appState.exploreSegment
             }
-
             .onChange(of: selectedSegment) { newValue in
                 updateTransitionDirection(for: newValue)
+                appState.exploreSegment = newValue
+            }
+            .onChange(of: appState.exploreSegment) { newValue in
+                guard newValue != selectedSegment else { return }
+                updateTransitionDirection(for: newValue)
+                selectedSegment = newValue
             }
         }
     }
@@ -108,6 +114,29 @@ struct ExploreView: View {
                 .padding(.leading, 4)
 
             FeaturedBannerView()
+                .padding(.bottom, 12)
+
+            HStack {
+                Text("Try Challenge")
+                    .font(.callout.weight(.semibold))
+                    .foregroundColor(.jeuneNearBlack)
+                    .padding(.leading, 4)
+                Spacer()
+                Button(action: { appState.exploreSegment = .challenges }) {
+                    Text("SEE ALL")
+                        .font(.jeuneCaptionBold)
+                        .foregroundColor(.jeunePrimaryDarkColor)
+                }
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 12) {
+                    ForEach(Challenge.sampleChallenges) { challenge in
+                        ChallengeCardView(challenge: challenge)
+                    }
+                }
+                .padding(.horizontal, 4)
+            }
         }
     }
 
@@ -190,12 +219,7 @@ private struct ArticleRow: View {
     }
 }
 
-/// Explore screen segments.
-private enum ExploreSegment: String, CaseIterable {
-    case home = "Home"
-    case learn = "Learn"
-    case challenges = "Challenges"
-}
+
 
 /// Fixed header containing toolbar actions and the segmented menu.
 private struct ExploreHeaderView: View {

--- a/Jeune/Features/RootTab/RootTabView.swift
+++ b/Jeune/Features/RootTab/RootTabView.swift
@@ -2,9 +2,12 @@
 import SwiftUI
 
 struct RootTabView: View {
+    @EnvironmentObject private var appState: AppState
+
     var body: some View {
-        TabView {
+        TabView(selection: $appState.selectedTab) {
             JeuneHomeView()
+                .tag(RootTab.today)
                 .tabItem {
                     VStack {
                         Image(systemName: "timer")
@@ -14,6 +17,7 @@ struct RootTabView: View {
                 }
 
             ExploreView()
+                .tag(RootTab.explore)
                 .tabItem {
                     VStack {
                         Image(systemName: "safari")
@@ -23,6 +27,7 @@ struct RootTabView: View {
                 }
 
             MeView()
+                .tag(RootTab.me)
                 .tabItem {
                     VStack {
                         Image(systemName: "person")
@@ -32,6 +37,7 @@ struct RootTabView: View {
                 }
 
             GenPlusView()
+                .tag(RootTab.plus)
                 .tabItem {
                     VStack {
                         Image(systemName: "flame")


### PR DESCRIPTION
## Summary
- center title in goal sheet and move close button to the left
- connect "See All" on the home challenge card to the Explore tab
- keep selected tab/segment in `AppState`
- add new horizontal "Try Challenge" section on Explore home
- provide reusable `ChallengeCardView` component

## Testing
- `swift test` *(fails: Package.swift missing)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841e2149a908324953088e2cc970106