### PR TITLE
Fix small logo size on Today view

### DIFF
--- a/Jeune/Features/JeuneHomeView.swift
+++ b/Jeune/Features/JeuneHomeView.swift
@@ -28,8 +28,8 @@ struct JeuneHomeView: View {
                     Image("logojeune")
                         .resizable()
                         .scaledToFit()
-                        // Smaller height keeps the navigation bar compact
-                        .frame(height: 60)
+                        // Increase the size so the logo is more prominent on the Today screen
+                        .frame(height: 100)
                 }
 
                 ToolbarItem(placement: .navigationBarTrailing) {


### PR DESCRIPTION
## Summary
- enlarge Today view logo for better visibility

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6841ed3437588324b15e0fbdf648e2f7