### PR TITLE
Refactor common UI pieces into reusable views

### DIFF
--- a/Jeune/Components/LegendItem.swift
+++ b/Jeune/Components/LegendItem.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Small label with a colored dot used in legends.
+struct LegendItem: View {
+    let color: Color
+    let label: String
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(color)
+                .frame(width: 8, height: 8)
+            Text(label)
+                .font(.jeuneCaptionBold)
+                .foregroundColor(.jeuneGrayColor)
+        }
+    }
+}
+
+#Preview {
+    LegendItem(color: .jeuneNutritionColor, label: "Nutrition")
+        .padding()
+}

--- a/Jeune/Components/SectionHeaderView.swift
+++ b/Jeune/Components/SectionHeaderView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Standard section header with optional trailing action.
+struct SectionHeaderView: View {
+    let title: String
+    var actionTitle: String? = nil
+    var action: (() -> Void)? = nil
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .font(.callout.weight(.semibold))
+                .foregroundColor(.jeuneNearBlack)
+            Spacer()
+            if let actionTitle {
+                if let action {
+                    Button(action: action) {
+                        Text(actionTitle.uppercased())
+                            .font(.jeuneCaptionBold)
+                            .foregroundColor(.jeunePrimaryDarkColor)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                } else {
+                    Text(actionTitle.uppercased())
+                        .font(.jeuneCaptionBold)
+                        .foregroundColor(.jeunePrimaryDarkColor)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 8) {
+        SectionHeaderView(title: "Title")
+        SectionHeaderView(title: "Title", actionTitle: "See All") {}
+    }
+    .padding()
+}

--- a/Jeune/Components/SettingRow.swift
+++ b/Jeune/Components/SettingRow.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// Row used in the settings screen with customizable trailing content.
+struct SettingRow<Content: View>: View {
+    let title: String
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .foregroundColor(.jeuneNearBlack)
+            Spacer()
+            content()
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+#Preview {
+    SettingRow(title: "Example") { Image(systemName: "chevron.right") }
+        .padding()
+}

--- a/Jeune/Features/RootTab/Explore/ExploreView.swift
+++ b/Jeune/Features/RootTab/Explore/ExploreView.swift
@@ -107,26 +107,16 @@ struct ExploreView: View {
 
     private var homeContent: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Featured")
-                .font(.callout.weight(.semibold))
-                .foregroundColor(.jeuneNearBlack)
-                .padding(.leading, 4)
+            SectionHeaderView(title: "Featured")
 
             FeaturedBannerView()
                 .padding(.bottom, 12)
 
-            HStack {
-                Text("Try Challenge")
-                    .font(.callout.weight(.semibold))
-                    .foregroundColor(.jeuneNearBlack)
-                    .padding(.leading, 4)
-                Spacer()
-                Button(action: { appState.exploreSegment = .challenges }) {
-                    Text("SEE ALL")
-                        .font(.jeuneCaptionBold)
-                        .foregroundColor(.jeunePrimaryDarkColor)
-                }
-            }
+            SectionHeaderView(
+                title: "Try Challenge",
+                actionTitle: "See All",
+                action: { appState.exploreSegment = .challenges }
+            )
 
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 12) {
@@ -145,9 +135,7 @@ struct ExploreView: View {
 
     private var learnContent: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("ARTICLES")
-                .font(.callout.weight(.semibold))
-                .foregroundColor(.jeuneNearBlack)
+            SectionHeaderView(title: "ARTICLES")
 
             ForEach(viewModel.filteredArticles) { article in
                 ArticleRow(article: article)
@@ -157,23 +145,14 @@ struct ExploreView: View {
 
     private var challengesContent: some View {
         VStack(alignment: .leading, spacing: 8) {
-
-            Text("Featured")
-                .font(.callout.weight(.semibold))
-                .foregroundColor(.jeuneNearBlack)
-                .padding(.leading, 4)
+            SectionHeaderView(title: "Featured")
 
             ChallengeBannerView()
 
                 .padding(.bottom, 12)
 
-            Text("Join a Challenge")
-                .font(.callout.weight(.semibold))
-                .foregroundColor(.jeuneNearBlack)
-                .padding(.top, 4)
-
-                .padding(.leading, 4)
-
+            SectionHeaderView(title: "Join a Challenge")
+                
             VStack(spacing: 0) {
                 ForEach(Challenge.sampleChallenges) { challenge in
                     NavigationLink(destination: Text(challenge.title)) {

--- a/Jeune/Features/RootTab/Me/MeView.swift
+++ b/Jeune/Features/RootTab/Me/MeView.swift
@@ -171,28 +171,18 @@ struct MeView: View {
 
     private var calendarSection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            sectionHeader(title: "Calendar")
+            SectionHeaderView(title: "Calendar")
             calendarCard
         }
     }
 
     private var metricsSection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            sectionHeader(title: "Weekly Metrics", action: "Manage Weight")
+            SectionHeaderView(title: "Weekly Metrics", actionTitle: "Manage Weight")
             metricsCard
         }
     }
 
-    private func sectionHeader(title: String, action: String = "See All") -> some View {
-        HStack {
-            Text(title)
-                .font(.callout.weight(.semibold))
-            Spacer()
-            Text(action.uppercased())
-                .font(.jeuneCaptionBold)
-                .foregroundColor(.jeunePrimaryDarkColor)
-        }
-    }
 
     private var calendarCard: some View {
         VStack(spacing: 16) {
@@ -222,21 +212,10 @@ struct MeView: View {
 
     private var calendarLegend: some View {
         HStack(spacing: 16) {
-            legendItem(color: .jeuneNutritionColor, label: "Nutrition")
-            legendItem(color: .jeuneActivityColor, label: "Activity")
-            legendItem(color: .jeuneRestorationColor, label: "Restoration")
-            legendItem(color: .jeuneSleepColor, label: "Sleep")
-        }
-    }
-
-    private func legendItem(color: Color, label: String) -> some View {
-        HStack(spacing: 4) {
-            Circle()
-                .fill(color)
-                .frame(width: 8, height: 8)
-            Text(label)
-                .font(.jeuneCaptionBold)
-                .foregroundColor(.jeuneGrayColor)
+            LegendItem(color: .jeuneNutritionColor, label: "Nutrition")
+            LegendItem(color: .jeuneActivityColor, label: "Activity")
+            LegendItem(color: .jeuneRestorationColor, label: "Restoration")
+            LegendItem(color: .jeuneSleepColor, label: "Sleep")
         }
     }
 
@@ -266,7 +245,7 @@ struct MeView: View {
 
     private var recentFastsSection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            sectionHeader(title: "Recent Fasts")
+            SectionHeaderView(title: "Recent Fasts")
             recentFastsCard
         }
     }
@@ -336,8 +315,8 @@ struct MeView: View {
 
     private var fastLegend: some View {
         HStack(spacing: 16) {
-            legendItem(color: .jeuneSuccessColor, label: "Goal Met")
-            legendItem(color: .jeuneGrayColor, label: "Goal Not Met")
+            LegendItem(color: .jeuneSuccessColor, label: "Goal Met")
+            LegendItem(color: .jeuneGrayColor, label: "Goal Not Met")
         }
     }
 

--- a/Jeune/Features/Settings/SettingsView.swift
+++ b/Jeune/Features/Settings/SettingsView.swift
@@ -46,14 +46,14 @@ struct SettingsView: View {
 
     private var preferencesSection: some View {
         VStack(spacing: 0) {
-            sectionHeader("Preferences")
+            SectionHeaderView(title: "Preferences")
             Divider().background(Color.jeuneGrayColor.opacity(0.3))
-            settingRow(title: "Timer Direction") {
+            SettingRow(title: "Timer Direction") {
                 Image(systemName: "chevron.right")
                     .foregroundColor(.jeuneDarkGray)
             }
             Divider().background(Color.jeuneGrayColor.opacity(0.3))
-            settingRow(title: "Weight Unit") {
+            SettingRow(title: "Weight Unit") {
                 Picker("Weight Unit", selection: $weightUnit) {
                     ForEach(WeightUnit.allCases) { unit in
                         Text(unit.rawValue).tag(unit)
@@ -72,7 +72,7 @@ struct SettingsView: View {
                 .padding(.horizontal, 4)
             Divider().background(Color.jeuneGrayColor.opacity(0.3))
             NavigationLink(destination: Text("Emails")) {
-                settingRow(title: "Emails") {
+                SettingRow(title: "Emails") {
                     Image(systemName: "chevron.right")
                         .foregroundColor(.jeuneDarkGray)
                 }
@@ -85,14 +85,14 @@ struct SettingsView: View {
 
     private var accountSection: some View {
         VStack(spacing: 0) {
-            sectionHeader("Account")
+            SectionHeaderView(title: "Account")
             Divider().background(Color.jeuneGrayColor.opacity(0.3))
-            settingRow(title: "Profile") {
+            SettingRow(title: "Profile") {
                 Image(systemName: "chevron.right")
                     .foregroundColor(.jeuneDarkGray)
             }
             Divider().background(Color.jeuneGrayColor.opacity(0.3))
-            settingRow(title: "Subscription") {
+            SettingRow(title: "Subscription") {
                 Image(systemName: "chevron.right")
                     .foregroundColor(.jeuneDarkGray)
             }
@@ -104,9 +104,9 @@ struct SettingsView: View {
 
     private var communitySection: some View {
         VStack(spacing: 0) {
-            sectionHeader("Community")
+            SectionHeaderView(title: "Community")
             Divider().background(Color.jeuneGrayColor.opacity(0.3))
-            settingRow(title: "Forums") {
+            SettingRow(title: "Forums") {
                 Image(systemName: "chevron.right")
                     .foregroundColor(.jeuneDarkGray)
             }
@@ -114,25 +114,6 @@ struct SettingsView: View {
         .padding()
         .background(Color.jeuneCardColor)
         .cornerRadius(DesignConstants.cornerRadius)
-    }
-
-    private func sectionHeader(_ title: String) -> some View {
-        HStack {
-            Text(title)
-                .font(.callout.weight(.semibold))
-            Spacer()
-        }
-        .padding(.bottom, 8)
-    }
-
-    private func settingRow<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
-        HStack {
-            Text(title)
-                .foregroundColor(.jeuneNearBlack)
-            Spacer()
-            content()
-        }
-        .padding(.vertical, 8)
     }
 }
 


### PR DESCRIPTION
## Summary
- add a reusable `SectionHeaderView`
- add flexible `SettingRow` and `LegendItem` components
- refactor Explore, Me and Settings screens to use the new components

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6841f11a1eec83249756ed6df1e693e7