### PR TITLE
Force app to stay in light mode

### DIFF
--- a/Jeune/JeuneApp.swift
+++ b/Jeune/JeuneApp.swift
@@ -13,12 +13,14 @@ struct JeuneApp: App {
     var body: some Scene {
         WindowGroup {
             RootTabView()
+                .preferredColorScheme(.light)
                 .environmentObject(appState)
                 .fullScreenCover(isPresented: Binding(
                     get: { !appState.onboardingCompleted },
                     set: { _ in }
                 )) {
                     OnboardingFlow()
+                        .preferredColorScheme(.light)
                         .environmentObject(appState)
                 }
         }


### PR DESCRIPTION
## Summary
- force the app to remain in light mode for now

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6841fb0d1ef8832491fd1b002b7bedde