### PR TITLE
Enable swipe gesture for Explore segments

### DIFF
--- a/Jeune/Features/RootTab/Explore/ExploreView.swift
+++ b/Jeune/Features/RootTab/Explore/ExploreView.swift
@@ -22,6 +22,9 @@ struct ExploreView: View {
 
     @Environment(\.jeuneSafeAreaInsets) private var safeAreaInsets: EdgeInsets
 
+    /// Minimum horizontal distance before a swipe gesture triggers a segment change.
+    private let swipeThreshold: CGFloat = 50
+
 
     /// Padding applied to the header. Removing a small amount keeps the
     /// toolbar consistent with the rest of the app.
@@ -58,6 +61,33 @@ struct ExploreView: View {
         previousSegment = newValue
     }
 
+    /// Changes the selected segment in the given direction if possible.
+    private func moveSegment(forward: Bool) {
+        let cases = ExploreSegment.allCases
+        guard let index = cases.firstIndex(of: selectedSegment) else { return }
+        let newIndex = forward ? index + 1 : index - 1
+        guard cases.indices.contains(newIndex) else { return }
+
+        withAnimation(.spring(response: 0.55, dampingFraction: 0.8)) {
+            selectedSegment = cases[newIndex]
+        }
+    }
+
+    /// Gesture that detects horizontal swipes to change segments.
+    private var swipeGesture: some Gesture {
+        DragGesture(minimumDistance: 20)
+            .onEnded { value in
+                let horizontal = value.translation.width
+                let vertical = value.translation.height
+                guard abs(horizontal) > abs(vertical), abs(horizontal) > swipeThreshold else { return }
+                if horizontal < 0 {
+                    moveSegment(forward: true)
+                } else {
+                    moveSegment(forward: false)
+                }
+            }
+    }
+
     var body: some View {
         NavigationStack {
             ScrollView {
@@ -84,6 +114,7 @@ struct ExploreView: View {
                 .padding(.bottom, 16)
             }
             .background(Color.jeuneCanvasColor.ignoresSafeArea())
+            .simultaneousGesture(swipeGesture)
             .navigationBarHidden(true)
             .overlay(alignment: .top) {
                 ExploreHeaderView(selected: $selectedSegment, animation: segmentNamespace)


### PR DESCRIPTION
## Summary
- add swipe gesture handling to `ExploreView`
- allow swiping left/right to change Explore segments

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_684257d81b9083249df13eb41c706a0c