### PR TITLE
Add start time editing sheet

### DIFF
--- a/Jeune/Components/FastTimerCardView.swift
+++ b/Jeune/Components/FastTimerCardView.swift
@@ -33,6 +33,9 @@ struct FastTimerCardView: View {
     /// Tapping "EDIT" while idle triggers this action. Optional.
     var editGoalAction: (() -> Void)? = nil
 
+    /// Tapping the "Started" pill triggers this action. Optional.
+    var startTimeAction: (() -> Void)? = nil
+
     /// Action for the primary button.
     var action: () -> Void
 
@@ -215,7 +218,14 @@ struct FastTimerCardView: View {
 
     private var statsRow: some View {
         HStack(spacing: 12) { // Spacing between the two white value pills
-            valuePill(value: formatDisplayDateString(from: startDate))
+            if let action = startTimeAction {
+                Button(action: action) {
+                    valuePill(value: formatDisplayDateString(from: startDate))
+                }
+                .buttonStyle(PlainButtonStyle())
+            } else {
+                valuePill(value: formatDisplayDateString(from: startDate))
+            }
             valuePill(value: formatDisplayDateString(from: goalTime))
         }
         .padding(8) // Padding inside the gray outer capsule for the white pills

--- a/Jeune/Features/FastingDemoView.swift
+++ b/Jeune/Features/FastingDemoView.swift
@@ -8,6 +8,7 @@ struct FastingDemoView: View {
     @State private var sinceLastFast: Int = 7 * 3600 + 25 * 60 + 41
     @State private var goalHours = 16
     @State private var showGoalPicker = false
+    @State private var showStartPicker = false
     @State private var startTime: Date?
 
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
@@ -19,13 +20,17 @@ struct FastingDemoView: View {
             goalHours: goalHours,
             goalTime: goalDateString,
             editGoalAction: { showGoalPicker = true },
-            action: toggleFasting
+            action: toggleFasting,
+            startTimeAction: { showStartPicker = true }
         )
 
         .animation(.easeInOut(duration: 0.3), value: isRunning)
 
         .sheet(isPresented: $showGoalPicker) {
             GoalPickerSheet(goalHours: $goalHours)
+        }
+        .sheet(isPresented: $showStartPicker) {
+            StartTimePickerSheet(startTime: $startTime)
         }
         .onReceive(timer) { _ in
             if isRunning {
@@ -172,6 +177,62 @@ private struct GoalCard: View {
             .clipShape(RoundedRectangle(cornerRadius: 12))
         }
         .buttonStyle(PlainButtonStyle())
+    }
+}
+
+private struct StartTimePickerSheet: View {
+    @Binding var startTime: Date?
+    @Environment(\.dismiss) var dismiss
+
+    @State private var tempDate: Date
+
+    init(startTime: Binding<Date?>) {
+        _startTime = startTime
+        _tempDate = State(initialValue: startTime.wrappedValue ?? Date())
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            HStack {
+                Spacer()
+                Button(action: { dismiss() }) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundColor(.black)
+                }
+            }
+            .padding()
+
+            HStack {
+                Text("When did you start fasting?")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(.black)
+                Spacer()
+            }
+            .padding(.horizontal)
+
+            DatePicker("", selection: $tempDate, displayedComponents: [.date, .hourAndMinute])
+                .datePickerStyle(.wheel)
+                .labelsHidden()
+                .padding(.horizontal)
+
+            Text(fastedText)
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(.jeuneGrayColor)
+
+            PrimaryCTAButton(title: "Save", background: .jeunePrimaryDarkColor) {
+                startTime = tempDate
+                dismiss()
+            }
+            .padding(.horizontal)
+        }
+    }
+
+    private var fastedText: String {
+        let diff = Date().timeIntervalSince(tempDate)
+        let hours = Int(diff) / 3600
+        let mins = (Int(diff) % 3600) / 60
+        return "You fasted for \(hours)h \(mins)m"
     }
 }
 


### PR DESCRIPTION
## Summary
- allow `FastTimerCardView` start time pill to open an action
- present a sheet from `FastingDemoView` to change the start time
- implement `StartTimePickerSheet` with date picker and save button

## Testing
- `swiftc Jeune/Components/FastTimerCardView.swift` *(fails: no such module SwiftUI)*

------
https://chatgpt.com/codex/tasks/task_b_68425f4e38e483248b75ec837ae3520d