### PR TITLE
Add Achievements placeholder screen

### DIFF
--- a/Jeune/Features/RootTab/Me/AchievementsView.swift
+++ b/Jeune/Features/RootTab/Me/AchievementsView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// Placeholder achievements screen.
+struct AchievementsView: View {
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                Image(systemName: "star.fill")
+                    .font(.system(size: 80))
+                    .foregroundColor(.jeunePrimaryDarkColor)
+
+                Text("Achievements")
+                    .font(.title2.bold())
+
+                Text("Coming soon...")
+                    .font(.body)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding()
+            .navigationTitle("Achievements")
+            .background(Color.jeuneCanvasColor.ignoresSafeArea())
+        }
+    }
+}
+
+#Preview {
+    AchievementsView()
+}

--- a/Jeune/Features/RootTab/Me/MeView.swift
+++ b/Jeune/Features/RootTab/Me/MeView.swift
@@ -150,23 +150,30 @@ struct MeView: View {
 
     /// Achievements block showing placeholder overlapping icons.
     private var achievementsBlock: some View {
-        VStack(spacing: 4) {
-            Text("ACHIEVEMENTS")
-                .font(.jeuneCaption)
-                .foregroundColor(.jeuneGrayColor)
+        NavigationLink(destination: AchievementsView()) {
+            VStack(spacing: 4) {
+                Text("ACHIEVEMENTS")
+                    .font(.jeuneCaption)
+                    .foregroundColor(.jeuneGrayColor)
 
-            HStack(spacing: -6) {
-                ForEach(0..<3) { _ in
-                    Circle()
-                        .fill(Color.jeunePrimaryDarkColor)
-                        .frame(width: 20, height: 20)
+                HStack(spacing: -4) {
+                    ForEach(0..<3) { _ in
+                        Circle()
+                            .fill(Color.jeunePrimaryDarkColor)
+                            .overlay(
+                                Circle()
+                                    .stroke(Color.white, lineWidth: 1)
+                            )
+                            .frame(width: 20, height: 20)
+                    }
+                    Text("+34")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(.black)
+                        .padding(.leading, 4)
                 }
-                Text("+35")
-                    .font(.system(size: 10, weight: .bold))
-                    .foregroundColor(.jeuneAccentColor)
-                    .padding(.leading, 4)
             }
         }
+        .buttonStyle(PlainButtonStyle())
     }
 
     private var calendarSection: some View {


### PR DESCRIPTION
## Summary
- add AchievementsView placeholder
- update Achievements block in MeView with navigation to the new view
- tweak circle styling and count text

## Testing
- `swiftc -parse Jeune/Features/RootTab/Me/AchievementsView.swift Jeune/Features/RootTab/Me/MeView.swift`
- `swiftc -parse `cat /tmp/swift_files.txt`

------
https://chatgpt.com/codex/tasks/task_b_6842615aa3448324a817c2648899f21a