### PR TITLE
Fix wrong argument order

### DIFF
--- a/Jeune/Features/FastingDemoView.swift
+++ b/Jeune/Features/FastingDemoView.swift
@@ -20,8 +20,8 @@ struct FastingDemoView: View {
             goalHours: goalHours,
             goalTime: goalDateString,
             editGoalAction: { showGoalPicker = true },
-            action: toggleFasting,
-            startTimeAction: { showStartPicker = true }
+            startTimeAction: { showStartPicker = true },
+            action: toggleFasting
         )
 
         .animation(.easeInOut(duration: 0.3), value: isRunning)


### PR DESCRIPTION
## Summary
- fix FastingDemoView to pass parameters in the order expected by `FastTimerCardView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_68435a8d7b3483249199be2ca8e9becc