### PR TITLE
Adjust fasting ring progress after editing start time

### DIFF
--- a/Jeune/Components/RingView.swift
+++ b/Jeune/Components/RingView.swift
@@ -16,7 +16,7 @@ struct RingView: View {
                 .stroke(Color.jeunePrimaryDarkColor,
                         style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
                 .rotationEffect(.degrees(-90))
-                .animation(.easeInOut, value: progress)
+                .animation(.easeInOut(duration: 0.6), value: progress)
         }
         .frame(width: diameter, height: diameter)
     }

--- a/Jeune/Features/FastingDemoView.swift
+++ b/Jeune/Features/FastingDemoView.swift
@@ -34,9 +34,20 @@ struct FastingDemoView: View {
         }
         .onReceive(timer) { _ in
             if isRunning {
-                elapsed += 1
+                if let start = startTime {
+                    elapsed = Int(Date().timeIntervalSince(start))
+                } else {
+                    elapsed = 0
+                }
             } else {
                 sinceLastFast += 1
+            }
+        }
+        .onChange(of: startTime) { newValue in
+            if isRunning, let start = newValue {
+                withAnimation(.easeInOut(duration: 0.6)) {
+                    elapsed = Int(Date().timeIntervalSince(start))
+                }
             }
         }
     }
@@ -221,7 +232,9 @@ private struct StartTimePickerSheet: View {
                 .foregroundColor(.jeuneGrayColor)
 
             PrimaryCTAButton(title: "Save", background: .jeunePrimaryDarkColor) {
-                startTime = tempDate
+                withAnimation(.easeInOut(duration: 0.6)) {
+                    startTime = tempDate
+                }
                 dismiss()
             }
             .padding(.horizontal)


### PR DESCRIPTION
## Summary
- animate RingView progress more smoothly
- update elapsed time based on the chosen start time
- animate ring when the start time is edited

## Testing
- `swift build -c release` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_68435eb3a92c8324bbf05a5db4356b5a