### PR TITLE
Add goal and post-fast states

### DIFF
--- a/Jeune/Components/RingView.swift
+++ b/Jeune/Components/RingView.swift
@@ -5,6 +5,7 @@ struct RingView: View {
     var progress: Double
     var diameter: CGFloat
     var lineWidth: CGFloat
+    var color: Color = .jeunePrimaryDarkColor
 
     var body: some View {
         ZStack {
@@ -13,7 +14,7 @@ struct RingView: View {
 
             Circle()
                 .trim(from: 0, to: min(progress, 1))
-                .stroke(Color.jeunePrimaryDarkColor,
+                .stroke(color,
                         style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
                 .rotationEffect(.degrees(-90))
                 .animation(.easeInOut(duration: 0.6), value: progress)
@@ -23,5 +24,5 @@ struct RingView: View {
 }
 
 #Preview {
-    RingView(progress: 0.7, diameter: 100, lineWidth: 12)
+    RingView(progress: 0.7, diameter: 100, lineWidth: 12, color: .jeunePrimaryDarkColor)
 }

--- a/Jeune/Core/Utilities/View+Jeune.swift
+++ b/Jeune/Core/Utilities/View+Jeune.swift
@@ -2,11 +2,11 @@ import SwiftUI
 
 extension View {
     /// Applies the standard Jeune card styling to a view.
-    func jeuneCard(padding: CGFloat = 16) -> some View {
+    func jeuneCard(padding: CGFloat = 16, background: Color = .jeuneCardColor) -> some View {
         self
             .padding(padding)
             .frame(maxWidth: .infinity)
-            .background(Color.jeuneCardColor)
+            .background(background)
             .cornerRadius(DesignConstants.cornerRadius)
             .shadow(
                 color: DesignConstants.cardShadow,


### PR DESCRIPTION
## Summary
- support more timer states for the fasting card
- update ring view to accept a color
- allow customizing card backgrounds
- demo view now handles goal reached and completed flows

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684361c855048324ac7479c60dcd3534