### PR TITLE
Refine Settings spacing

### DIFF
--- a/Jeune/Components/SettingRow.swift
+++ b/Jeune/Components/SettingRow.swift
@@ -8,11 +8,12 @@ struct SettingRow<Content: View>: View {
     var body: some View {
         HStack {
             Text(title)
+                .fontWeight(.semibold)
                 .foregroundColor(.jeuneNearBlack)
             Spacer()
             content()
         }
-        .padding(.vertical, 8)
+        .padding(.vertical, 12)
     }
 }
 

--- a/Jeune/Features/Settings/SettingsView.swift
+++ b/Jeune/Features/Settings/SettingsView.swift
@@ -28,7 +28,7 @@ struct SettingsView: View {
     }
 
     private var header: some View {
-        HStack {
+        HStack(spacing: 0) {
             Button(action: { dismiss() }) {
                 Image(systemName: "xmark")
                     .font(.system(size: 16, weight: .bold))
@@ -41,79 +41,93 @@ struct SettingsView: View {
                 .font(.subheadline.weight(.semibold))
                 .foregroundColor(.black)
         )
-        .padding()
+        .padding(.trailing)
+        .padding(.vertical)
     }
 
     private var preferencesSection: some View {
-        VStack(spacing: 0) {
-            SectionHeaderView(title: "Preferences")
-            Divider().background(Color.jeuneGrayColor.opacity(0.3))
-            SettingRow(title: "Timer Direction") {
-                Image(systemName: "chevron.right")
-                    .foregroundColor(.jeuneDarkGray)
-            }
-            Divider().background(Color.jeuneGrayColor.opacity(0.3))
-            SettingRow(title: "Weight Unit") {
-                Picker("Weight Unit", selection: $weightUnit) {
-                    ForEach(WeightUnit.allCases) { unit in
-                        Text(unit.rawValue).tag(unit)
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Preferences")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(.jeuneNearBlack)
+
+            VStack(spacing: 0) {
+                SettingRow(title: "Timer Direction") {
+                    Image(systemName: "chevron.right")
+                        .fontWeight(.bold)
+                        .foregroundColor(.jeuneGrayColor)
+                }
+                Divider().background(Color.jeuneGrayColor.opacity(0.15))
+                SettingRow(title: "Weight Unit") {
+                    Picker("Weight Unit", selection: $weightUnit) {
+                        ForEach(WeightUnit.allCases) { unit in
+                            Text(unit.rawValue).tag(unit)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(maxWidth: 120)
+                }
+                Divider().background(Color.jeuneGrayColor.opacity(0.15))
+                Toggle("Dark Mode", isOn: $darkMode)
+                    .toggleStyle(SwitchToggleStyle(tint: .jeunePrimaryDarkColor))
+                    .padding(.vertical, 12)
+                    .padding(.horizontal, 4)
+                Divider().background(Color.jeuneGrayColor.opacity(0.15))
+                Toggle("Notifications", isOn: $notifications)
+                    .toggleStyle(SwitchToggleStyle(tint: .jeunePrimaryDarkColor))
+                    .padding(.vertical, 12)
+                    .padding(.horizontal, 4)
+                Divider().background(Color.jeuneGrayColor.opacity(0.15))
+                NavigationLink(destination: Text("Emails")) {
+                    SettingRow(title: "Emails") {
+                        Image(systemName: "chevron.right")
+                            .fontWeight(.bold)
+                            .foregroundColor(.jeuneGrayColor)
                     }
                 }
-                .pickerStyle(.segmented)
-                .frame(maxWidth: 120)
             }
-            Divider().background(Color.jeuneGrayColor.opacity(0.3))
-            Toggle("Dark Mode", isOn: $darkMode)
-                .toggleStyle(SwitchToggleStyle(tint: .jeunePrimaryDarkColor))
-                .padding(.horizontal, 4)
-            Divider().background(Color.jeuneGrayColor.opacity(0.3))
-            Toggle("Notifications", isOn: $notifications)
-                .toggleStyle(SwitchToggleStyle(tint: .jeunePrimaryDarkColor))
-                .padding(.horizontal, 4)
-            Divider().background(Color.jeuneGrayColor.opacity(0.3))
-            NavigationLink(destination: Text("Emails")) {
-                SettingRow(title: "Emails") {
-                    Image(systemName: "chevron.right")
-                        .foregroundColor(.jeuneDarkGray)
-                }
-            }
+            .jeuneCard()
         }
-        .padding()
-        .background(Color.jeuneCardColor)
-        .cornerRadius(DesignConstants.cornerRadius)
     }
 
     private var accountSection: some View {
-        VStack(spacing: 0) {
-            SectionHeaderView(title: "Account")
-            Divider().background(Color.jeuneGrayColor.opacity(0.3))
-            SettingRow(title: "Profile") {
-                Image(systemName: "chevron.right")
-                    .foregroundColor(.jeuneDarkGray)
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Account")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(.jeuneNearBlack)
+
+            VStack(spacing: 0) {
+                SettingRow(title: "Profile") {
+                    Image(systemName: "chevron.right")
+                        .fontWeight(.bold)
+                        .foregroundColor(.jeuneGrayColor)
+                }
+                Divider().background(Color.jeuneGrayColor.opacity(0.15))
+                SettingRow(title: "Subscription") {
+                    Image(systemName: "chevron.right")
+                        .fontWeight(.bold)
+                        .foregroundColor(.jeuneGrayColor)
+                }
             }
-            Divider().background(Color.jeuneGrayColor.opacity(0.3))
-            SettingRow(title: "Subscription") {
-                Image(systemName: "chevron.right")
-                    .foregroundColor(.jeuneDarkGray)
-            }
+            .jeuneCard()
         }
-        .padding()
-        .background(Color.jeuneCardColor)
-        .cornerRadius(DesignConstants.cornerRadius)
     }
 
     private var communitySection: some View {
-        VStack(spacing: 0) {
-            SectionHeaderView(title: "Community")
-            Divider().background(Color.jeuneGrayColor.opacity(0.3))
-            SettingRow(title: "Forums") {
-                Image(systemName: "chevron.right")
-                    .foregroundColor(.jeuneDarkGray)
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Community")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(.jeuneNearBlack)
+
+            VStack(spacing: 0) {
+                SettingRow(title: "Forums") {
+                    Image(systemName: "chevron.right")
+                        .fontWeight(.bold)
+                        .foregroundColor(.jeuneGrayColor)
+                }
             }
+            .jeuneCard()
         }
-        .padding()
-        .background(Color.jeuneCardColor)
-        .cornerRadius(DesignConstants.cornerRadius)
     }
 }
 


### PR DESCRIPTION
## Summary
- adjust header padding so the dismiss button hugs the left edge
- ensure Dark Mode and Notifications toggles have the same vertical padding as other rows
- apply `jeuneCard()` styling to each section for consistent shadows

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6843642d555c832497f0b7e34cdeab26