### PR TITLE
Add initial authentication flow UI

### DIFF
--- a/Jeune/Core/Models/AppState.swift
+++ b/Jeune/Core/Models/AppState.swift
@@ -17,6 +17,9 @@ class AppState: ObservableObject {
     /// Indicates if the onboarding flow has been completed.
     @Published var onboardingCompleted: Bool = false
 
+    /// Indicates if the user has successfully authenticated.
+    @Published var isAuthenticated: Bool = false
+
     /// Currently selected tab in ``RootTabView``.
     @Published var selectedTab: RootTab = .today
 

--- a/Jeune/Features/Auth/AuthenticationFlow.swift
+++ b/Jeune/Features/Auth/AuthenticationFlow.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// Flow managing the authentication screens.
+struct AuthenticationFlow: View {
+    @EnvironmentObject var appState: AppState
+    @State private var screen: Screen = .login
+
+    enum Screen {
+        case login
+        case signUp
+        case forgotPassword
+    }
+
+    var body: some View {
+        switch screen {
+        case .login:
+            LoginView(showSignUp: { screen = .signUp },
+                      showForgot: { screen = .forgotPassword },
+                      complete: { appState.isAuthenticated = true })
+        case .signUp:
+            SignUpView(showLogin: { screen = .login },
+                       complete: { appState.isAuthenticated = true })
+        case .forgotPassword:
+            ForgotPasswordView(backAction: { screen = .login })
+        }
+    }
+}
+
+#Preview {
+    AuthenticationFlow().environmentObject(AppState())
+}

--- a/Jeune/Features/Auth/ForgotPasswordView.swift
+++ b/Jeune/Features/Auth/ForgotPasswordView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Screen for requesting a password reset email.
+struct ForgotPasswordView: View {
+    var backAction: () -> Void
+
+    @State private var email: String = ""
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Spacer()
+                Image("logojeune")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: 80)
+                TextField("Email", text: $email)
+                    .textFieldStyle(.roundedBorder)
+                PrimaryButton(title: "Send Reset Link", action: backAction)
+                Spacer()
+                Button(action: backAction) {
+                    Text("Back to Login")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundColor(.jeunePrimaryDarkColor)
+                }
+            }
+            .padding()
+            .background(Color.jeuneCanvasColor.ignoresSafeArea())
+            .navigationBarHidden(true)
+        }
+    }
+}
+
+#Preview {
+    ForgotPasswordView(backAction: {})
+        .environmentObject(AppState())
+}

--- a/Jeune/Features/Auth/LoginView.swift
+++ b/Jeune/Features/Auth/LoginView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+/// Simple login screen with email/password fields and social sign in.
+struct LoginView: View {
+    var showSignUp: () -> Void
+    var showForgot: () -> Void
+    var complete: () -> Void
+
+    @State private var email: String = ""
+    @State private var password: String = ""
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Spacer()
+                Image("logojeune")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: 80)
+                VStack(spacing: 16) {
+                    TextField("Email", text: $email)
+                        .textFieldStyle(.roundedBorder)
+                    SecureField("Password", text: $password)
+                        .textFieldStyle(.roundedBorder)
+                }
+                PrimaryButton(title: "Log In", action: complete)
+                Button(action: showForgot) {
+                    Text("Forgot password?")
+                        .font(.footnote)
+                        .foregroundColor(.jeunePrimaryDarkColor)
+                }
+                HStack {
+                    Rectangle()
+                        .fill(Color.jeuneGrayColor.opacity(0.4))
+                        .frame(height: 1)
+                    Text("OR")
+                        .font(.caption)
+                        .foregroundColor(.jeuneGrayColor)
+                    Rectangle()
+                        .fill(Color.jeuneGrayColor.opacity(0.4))
+                        .frame(height: 1)
+                }
+                Button(action: complete) {
+                    HStack {
+                        Image(systemName: "globe")
+                        Text("Continue with Google")
+                            .fontWeight(.semibold)
+                    }
+                    .foregroundColor(.black)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.white)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color.jeuneGrayColor.opacity(0.3), lineWidth: 1)
+                    )
+                }
+                Spacer()
+                Button(action: showSignUp) {
+                    Text("Don't have an account? Sign Up")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundColor(.jeunePrimaryDarkColor)
+                }
+            }
+            .padding()
+            .background(Color.jeuneCanvasColor.ignoresSafeArea())
+            .navigationBarHidden(true)
+        }
+    }
+}
+
+#Preview {
+    LoginView(showSignUp: {}, showForgot: {}, complete: {})
+        .environmentObject(AppState())
+}

--- a/Jeune/Features/Auth/SignUpView.swift
+++ b/Jeune/Features/Auth/SignUpView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// Simple sign up screen with email and password fields.
+struct SignUpView: View {
+    var showLogin: () -> Void
+    var complete: () -> Void
+
+    @State private var email: String = ""
+    @State private var password: String = ""
+    @State private var confirm: String = ""
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Spacer()
+                Image("logojeune")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: 80)
+                VStack(spacing: 16) {
+                    TextField("Email", text: $email)
+                        .textFieldStyle(.roundedBorder)
+                    SecureField("Password", text: $password)
+                        .textFieldStyle(.roundedBorder)
+                    SecureField("Confirm Password", text: $confirm)
+                        .textFieldStyle(.roundedBorder)
+                }
+                PrimaryButton(title: "Sign Up", action: complete)
+                Spacer()
+                Button(action: showLogin) {
+                    Text("Already have an account? Log In")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundColor(.jeunePrimaryDarkColor)
+                }
+            }
+            .padding()
+            .background(Color.jeuneCanvasColor.ignoresSafeArea())
+            .navigationBarHidden(true)
+        }
+    }
+}
+
+#Preview {
+    SignUpView(showLogin: {}, complete: {})
+        .environmentObject(AppState())
+}

--- a/Jeune/JeuneApp.swift
+++ b/Jeune/JeuneApp.swift
@@ -23,6 +23,14 @@ struct JeuneApp: App {
                         .preferredColorScheme(.light)
                         .environmentObject(appState)
                 }
+                .fullScreenCover(isPresented: Binding(
+                    get: { appState.onboardingCompleted && !appState.isAuthenticated },
+                    set: { _ in }
+                )) {
+                    AuthenticationFlow()
+                        .preferredColorScheme(.light)
+                        .environmentObject(appState)
+                }
         }
     }
 }


### PR DESCRIPTION
## Summary
- create new Auth flow with login, sign up and forgot password screens
- track onboarding and authentication state in `AppState`
- present authentication flow after onboarding is complete

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6847345cc768832498399af5049ccce2