### PR TITLE
Revamp onboarding with single welcome screen and multi-step signup

### DIFF
--- a/Jeune/Components/AuthTextFieldStyle.swift
+++ b/Jeune/Components/AuthTextFieldStyle.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// Text field style used for authentication screens with larger height and subtle shadow.
+struct AuthTextFieldStyle: TextFieldStyle {
+    func _body(configuration: TextField<Self._Label>) -> some View {
+        configuration
+            .padding(.horizontal, 16)
+            .frame(height: 50)
+            .background(
+                RoundedRectangle(cornerRadius: 25, style: .continuous)
+                    .fill(Color.white)
+                    .shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 2)
+            )
+    }
+}
+
+#Preview {
+    TextField("Email", text: .constant(""))
+        .textFieldStyle(AuthTextFieldStyle())
+        .padding()
+        .previewLayout(.sizeThatFits)
+}

--- a/Jeune/Core/Models/AppState.swift
+++ b/Jeune/Core/Models/AppState.swift
@@ -26,6 +26,9 @@ class AppState: ObservableObject {
     /// Selected segment in ``ExploreView``.
     @Published var exploreSegment: ExploreSegment = .home
 
+    /// Starting screen when presenting ``AuthenticationFlow``.
+    @Published var authStartScreen: AuthenticationFlow.Screen = .login
+
     init() {
         // Initialize state
     }

--- a/Jeune/Features/Auth/AuthenticationFlow.swift
+++ b/Jeune/Features/Auth/AuthenticationFlow.swift
@@ -3,7 +3,11 @@ import SwiftUI
 /// Flow managing the authentication screens.
 struct AuthenticationFlow: View {
     @EnvironmentObject var appState: AppState
-    @State private var screen: Screen = .login
+    @State private var screen: Screen
+
+    init(startScreen: Screen = .login) {
+        _screen = State(initialValue: startScreen)
+    }
 
     enum Screen {
         case login

--- a/Jeune/Features/Auth/ForgotPasswordView.swift
+++ b/Jeune/Features/Auth/ForgotPasswordView.swift
@@ -15,8 +15,10 @@ struct ForgotPasswordView: View {
                     .scaledToFit()
                     .frame(height: 80)
                 TextField("Email", text: $email)
-                    .textFieldStyle(.roundedBorder)
-                PrimaryButton(title: "Send Reset Link", action: backAction)
+                    .textFieldStyle(AuthTextFieldStyle())
+                PrimaryCTAButton(title: "Send Reset Link", background: .jeunePrimaryDarkColor) {
+                    backAction()
+                }
                 Spacer()
                 Button(action: backAction) {
                     Text("Back to Login")

--- a/Jeune/Features/Auth/LoginView.swift
+++ b/Jeune/Features/Auth/LoginView.swift
@@ -19,11 +19,13 @@ struct LoginView: View {
                     .frame(height: 80)
                 VStack(spacing: 16) {
                     TextField("Email", text: $email)
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(AuthTextFieldStyle())
                     SecureField("Password", text: $password)
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(AuthTextFieldStyle())
                 }
-                PrimaryButton(title: "Log In", action: complete)
+                PrimaryCTAButton(title: "Log In", background: .jeunePrimaryDarkColor) {
+                    complete()
+                }
                 Button(action: showForgot) {
                     Text("Forgot password?")
                         .font(.footnote)
@@ -40,20 +42,8 @@ struct LoginView: View {
                         .fill(Color.jeuneGrayColor.opacity(0.4))
                         .frame(height: 1)
                 }
-                Button(action: complete) {
-                    HStack {
-                        Image(systemName: "globe")
-                        Text("Continue with Google")
-                            .fontWeight(.semibold)
-                    }
-                    .foregroundColor(.black)
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(Color.white)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(Color.jeuneGrayColor.opacity(0.3), lineWidth: 1)
-                    )
+                PrimaryCTAButton(title: "Continue with Google", background: .black) {
+                    complete()
                 }
                 Spacer()
                 Button(action: showSignUp) {

--- a/Jeune/Features/Auth/SignUpView.swift
+++ b/Jeune/Features/Auth/SignUpView.swift
@@ -1,13 +1,21 @@
 import SwiftUI
 
-/// Simple sign up screen with email and password fields.
+/// Multi-step sign up flow with email, password and personal details stages.
 struct SignUpView: View {
     var showLogin: () -> Void
     var complete: () -> Void
 
+    private enum Step {
+        case email, password, details
+    }
+
+    @State private var step: Step = .email
     @State private var email: String = ""
     @State private var password: String = ""
-    @State private var confirm: String = ""
+    @State private var firstName: String = ""
+    @State private var lastName: String = ""
+    @State private var sex: String = "Female"
+    @State private var birthDate: Date = Date()
 
     var body: some View {
         NavigationStack {
@@ -17,15 +25,16 @@ struct SignUpView: View {
                     .resizable()
                     .scaledToFit()
                     .frame(height: 80)
-                VStack(spacing: 16) {
-                    TextField("Email", text: $email)
-                        .textFieldStyle(.roundedBorder)
-                    SecureField("Password", text: $password)
-                        .textFieldStyle(.roundedBorder)
-                    SecureField("Confirm Password", text: $confirm)
-                        .textFieldStyle(.roundedBorder)
+
+                switch step {
+                case .email:
+                    emailStep
+                case .password:
+                    passwordStep
+                case .details:
+                    detailsStep
                 }
-                PrimaryButton(title: "Sign Up", action: complete)
+
                 Spacer()
                 Button(action: showLogin) {
                     Text("Already have an account? Log In")
@@ -36,6 +45,66 @@ struct SignUpView: View {
             .padding()
             .background(Color.jeuneCanvasColor.ignoresSafeArea())
             .navigationBarHidden(true)
+        }
+    }
+
+    private var emailStep: some View {
+        VStack(spacing: 16) {
+            PrimaryCTAButton(title: "Continue with Google", background: .black) {
+                complete()
+            }
+            HStack {
+                Rectangle()
+                    .fill(Color.jeuneGrayColor.opacity(0.4))
+                    .frame(height: 1)
+                Text("OR")
+                    .font(.caption)
+                    .foregroundColor(.jeuneGrayColor)
+                Rectangle()
+                    .fill(Color.jeuneGrayColor.opacity(0.4))
+                    .frame(height: 1)
+            }
+            TextField("Email", text: $email)
+                .textFieldStyle(AuthTextFieldStyle())
+            PrimaryCTAButton(title: "Continue",
+                             background: email.isEmpty ? .jeuneGrayColor : .jeunePrimaryDarkColor) {
+                step = .password
+            }
+            .disabled(email.isEmpty)
+        }
+    }
+
+    private var passwordStep: some View {
+        VStack(spacing: 16) {
+            SecureField("Create Password", text: $password)
+                .textFieldStyle(AuthTextFieldStyle())
+            PrimaryCTAButton(title: "Continue",
+                             background: password.isEmpty ? .jeuneGrayColor : .jeunePrimaryDarkColor) {
+                step = .details
+            }
+            .disabled(password.isEmpty)
+        }
+    }
+
+    private var detailsStep: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                TextField("First Name", text: $firstName)
+                    .textFieldStyle(AuthTextFieldStyle())
+                TextField("Last Name", text: $lastName)
+                    .textFieldStyle(AuthTextFieldStyle())
+                Picker("Sex", selection: $sex) {
+                    Text("Female").tag("Female")
+                    Text("Male").tag("Male")
+                    Text("Other").tag("Other")
+                }
+                .pickerStyle(SegmentedPickerStyle())
+                DatePicker("Birth Date", selection: $birthDate, displayedComponents: .date)
+                    .datePickerStyle(.compact)
+                PrimaryCTAButton(title: "Finish", background: .jeunePrimaryDarkColor) {
+                    complete()
+                }
+            }
         }
     }
 }

--- a/Jeune/Features/Onboarding/OnboardingFlow.swift
+++ b/Jeune/Features/Onboarding/OnboardingFlow.swift
@@ -1,95 +1,52 @@
 import SwiftUI
 
-struct OnboardingPage: Identifiable {
-    let id = UUID()
-    let symbol: String
-    let title: String
-    let subtitle: String
-}
-
+/// Single page welcome screen shown on first launch.
 struct OnboardingFlow: View {
     @EnvironmentObject var appState: AppState
-    @State private var pageIndex = 0
-
-    private let pages: [OnboardingPage] = [
-        OnboardingPage(symbol: "timer",
-                       title: "Track your fasts",
-                       subtitle: "Start, pause, or edit anytime."),
-        OnboardingPage(symbol: "flame",
-                       title: "Understand your zones",
-                       subtitle: "See what's happening inside your body."),
-        OnboardingPage(symbol: "doc.text.image",
-                       title: "Learn from experts",
-                       subtitle: "Daily articles & videos keep you motivated."),
-        OnboardingPage(symbol: "checkmark.seal",
-                       title: "Ready?",
-                       subtitle: "Let’s set up your first fast.")
-    ]
-
-    init() {
-        UIPageControl.appearance().currentPageIndicatorTintColor = UIColor(Color.jeunePrimaryDarkColor)
-    }
 
     var body: some View {
-        TabView(selection: $pageIndex) {
-            ForEach(Array(pages.enumerated()), id: \.offset) { index, page in
-                OnboardingPageView(page: page,
-                                    showSkip: index < pages.count - 1,
-                                    continueAction: {
-                                        if index < pages.count - 1 {
-                                            withAnimation { pageIndex += 1 }
-                                        } else {
-                                            appState.onboardingCompleted = true
-                                        }
-                                    },
-                                    skipAction: {
-                                        withAnimation { pageIndex = pages.count - 1 }
-                                    })
-                .tag(index)
+        VStack(spacing: 24) {
+            Spacer()
+            Image("logojeune")
+                .resizable()
+                .scaledToFit()
+                .frame(height: 120)
+                .padding(.bottom, 20)
+
+            Text("Start your journey with Jeune today")
+                .font(.jeuneLargeTitle)
+                .multilineTextAlignment(.center)
+                .foregroundColor(.jeuneNearBlack)
+                .padding(.horizontal)
+
+            Text("Build a healthy lifestyle that still lets you enjoy your life.")
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .foregroundColor(.jeuneGrayColor)
+                .padding(.horizontal)
+
+            PrimaryCTAButton(title: "Sign in with Google", background: .black) {
+                appState.isAuthenticated = true
+                appState.onboardingCompleted = true
             }
+            PrimaryCTAButton(title: "Other Sign Up Options",
+                             background: .jeuneGrayColor,
+                             foreground: .jeuneNearBlack) {
+                appState.authStartScreen = .signUp
+                appState.onboardingCompleted = true
+            }
+            Button(action: {
+                appState.authStartScreen = .login
+                appState.onboardingCompleted = true
+            }) {
+                Text("Already have an account?")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundColor(.jeunePrimaryDarkColor)
+            }
+            Spacer()
         }
-        .tabViewStyle(.page)
-    }
-}
-
-private struct OnboardingPageView: View {
-    let page: OnboardingPage
-    let showSkip: Bool
-    var continueAction: () -> Void
-    var skipAction: () -> Void
-
-    var body: some View {
-        ZStack(alignment: .topTrailing) {
-            VStack {
-                Spacer()
-
-                Image(systemName: page.symbol)
-                    .font(.system(size: 56))
-                    .symbolRenderingMode(.multicolor)
-                    .padding(.bottom, 24)
-
-                Text(page.title)
-                    .font(.jeuneLargeTitle)
-                    .padding(.bottom, 8)
-
-                Text(page.subtitle)
-                    .font(.body)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 40)
-
-                Spacer()
-
-                PrimaryButton(title: "Continue", action: continueAction)
-                    .padding(.bottom, 40)
-            }
-
-            if showSkip {
-                Button("Skip", action: skipAction)
-                    .font(.caption)
-                    .textCase(.uppercase)
-                    .padding([.top, .trailing], 20)
-            }
-        }
+        .padding()
+        .background(Color.jeuneCanvasColor.ignoresSafeArea())
     }
 }
 

--- a/Jeune/JeuneApp.swift
+++ b/Jeune/JeuneApp.swift
@@ -27,7 +27,7 @@ struct JeuneApp: App {
                     get: { appState.onboardingCompleted && !appState.isAuthenticated },
                     set: { _ in }
                 )) {
-                    AuthenticationFlow()
+                    AuthenticationFlow(startScreen: appState.authStartScreen)
                         .preferredColorScheme(.light)
                         .environmentObject(appState)
                 }


### PR DESCRIPTION
## Summary
- simplify onboarding flow to one page with welcome message, Google sign-in, and links to login or signup
- create reusable `AuthTextFieldStyle` for larger text fields with shadows
- redesign login, signup and forgot-password screens with new text field style and capsule buttons
- implement multi-step signup (email → password → personal details)
- allow selecting initial auth screen via `AppState`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_68473b5716f483249ba3ba95334e1f02